### PR TITLE
Add LINQ-friendly overloads to StringFilters

### DIFF
--- a/src/csharp/FpFilters.Tests/StringFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/StringFiltersBddTests.cs
@@ -245,6 +245,8 @@ namespace FpFilters.StringFilters.BddTests
         private void WhenStartsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.StartsWith(substring, comparisonType)(arg);
         private void WhenEndsWithComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.EndsWith(arg, substring, comparisonType);
         private void WhenEndsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.EndsWith(substring, comparisonType)(arg);
+        private void WhenIncludesComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.Includes(arg, substring, comparisonType);
+        private void WhenIncludesLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.Includes(substring, comparisonType)(arg);
 
         [Scenario]
         public void Should_check_startswith_and_endswith_with_stringcomparison()
@@ -274,6 +276,30 @@ namespace FpFilters.StringFilters.BddTests
                 _ => WhenEndsWithLinqComparison("WORLD", StringComparison.OrdinalIgnoreCase),
                 _ => ThenResultShouldBeTrue(),
                 _ => WhenEndsWithLinqComparison("WORLD", StringComparison.Ordinal),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_includes_with_stringcomparison()
+        {
+            Runner.RunScenario(
+                _ => GivenString("Hello World"),
+                _ => WhenIncludesComparison("world", StringComparison.OrdinalIgnoreCase),
+                _ => ThenResultShouldBeTrue(),
+                _ => WhenIncludesComparison("world", StringComparison.Ordinal),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_support_linq_overloads_for_includes_with_stringcomparison()
+        {
+            Runner.RunScenario(
+                _ => GivenString("Hello World"),
+                _ => WhenIncludesLinqComparison("world", StringComparison.OrdinalIgnoreCase),
+                _ => ThenResultShouldBeTrue(),
+                _ => WhenIncludesLinqComparison("world", StringComparison.Ordinal),
                 _ => ThenResultShouldBeFalse()
             );
         }

--- a/src/csharp/FpFilters/StringFilters/StringFilters.cs
+++ b/src/csharp/FpFilters/StringFilters/StringFilters.cs
@@ -22,6 +22,10 @@ namespace FpFilters.StringFilters
         public static bool Includes(string? arg, string substring) => arg?.Contains(substring) ?? false;
         public static Func<string?, bool> Includes(string substring) => arg => Includes(arg, substring);
 
+        // Returns true if the string includes the specified substring, with StringComparison
+        public static bool Includes(string? arg, string substring, StringComparison comparison) => arg?.IndexOf(substring, comparison) >= 0;
+        public static Func<string?, bool> Includes(string substring, StringComparison comparison) => arg => Includes(arg, substring, comparison);
+
         // Returns true if the argument is an empty string ('')
         public static bool IsEmptyString(string? arg) => arg == "";
 


### PR DESCRIPTION
Introduced Func<string?, bool> overloads for StartsWith, EndsWith, Includes, Matches, and DoesNotMatch to support LINQ and functional usage. Added corresponding tests to verify the new overloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added functional-style string filter overloads that return predicates for StartsWith, EndsWith, Includes, Matches, DoesNotMatch, including variants that accept comparison options for flexible case/culture-aware matching.

- Tests
  - Added comprehensive scenarios validating the new LINQ-friendly and comparison-aware overloads across multiple cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->