### PR TITLE
Add LINQ-friendly overloads to ArrayFilters

### DIFF
--- a/src/csharp/FpFilters.Tests/ArrayFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/ArrayFiltersBddTests.cs
@@ -9,8 +9,11 @@ namespace FpFilters.ArrayFilters.BddTests
 
         private void GivenArray(params int[] values) => arr = values;
         private void WhenIsIncludedIn(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsIncludedIn(value, arr);
+        private void WhenIsIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsIncludedIn(arr)(value);
         private void WhenIsNotIncludedIn(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsNotIncludedIn(value, arr);
+        private void WhenIsNotIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsNotIncludedIn(arr)(value);
         private void WhenEveryElement(Func<int, bool> condition) => result = FpFilters.ArrayFilters.ArrayFilters.EveryElement(arr, condition);
+        private void WhenEveryElement_Linq(Func<int, bool> condition) => result = FpFilters.ArrayFilters.ArrayFilters.EveryElement(condition)(arr);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -22,6 +25,10 @@ namespace FpFilters.ArrayFilters.BddTests
                 _ => WhenIsIncludedIn(2),
                 _ => ThenResultShouldBeTrue(),
                 _ => WhenIsIncludedIn(4),
+                _ => ThenResultShouldBeFalse(),
+                _ => WhenIsIncludedIn_Linq(2),
+                _ => ThenResultShouldBeTrue(),
+                _ => WhenIsIncludedIn_Linq(4),
                 _ => ThenResultShouldBeFalse()
             );
         }
@@ -34,6 +41,10 @@ namespace FpFilters.ArrayFilters.BddTests
                 _ => WhenIsNotIncludedIn(4),
                 _ => ThenResultShouldBeTrue(),
                 _ => WhenIsNotIncludedIn(2),
+                _ => ThenResultShouldBeFalse(),
+                _ => WhenIsNotIncludedIn_Linq(4),
+                _ => ThenResultShouldBeTrue(),
+                _ => WhenIsNotIncludedIn_Linq(2),
                 _ => ThenResultShouldBeFalse()
             );
         }
@@ -46,6 +57,10 @@ namespace FpFilters.ArrayFilters.BddTests
                 _ => WhenEveryElement(x => x % 2 == 0),
                 _ => ThenResultShouldBeTrue(),
                 _ => WhenEveryElement(x => x > 4),
+                _ => ThenResultShouldBeFalse(),
+                _ => WhenEveryElement_Linq(x => x % 2 == 0),
+                _ => ThenResultShouldBeTrue(),
+                _ => WhenEveryElement_Linq(x => x > 4),
                 _ => ThenResultShouldBeFalse()
             );
         }

--- a/src/csharp/FpFilters.sln
+++ b/src/csharp/FpFilters.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FpFilters", "FpFilters\FpFi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FpFilters.Tests", "FpFilters.Tests\FpFilters.Tests.csproj", "{4FCBD168-47C1-46B2-8C93-3FAB5CF867F0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		run-tests-with-coverage.ps1 = run-tests-with-coverage.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/csharp/FpFilters/ArrayFilters/ArrayFilters.cs
+++ b/src/csharp/FpFilters/ArrayFilters/ArrayFilters.cs
@@ -7,17 +7,23 @@ namespace FpFilters.ArrayFilters
         {
             return comparisonArray != null && comparisonArray.Contains(arg);
         }
+        // LINQ-friendly overload
+        public static Func<T, bool> IsIncludedIn<T>(T[] comparisonArray) => arg => IsIncludedIn(arg, comparisonArray);
 
         // Checks if the argument is NOT included in the comparison array
         public static bool IsNotIncludedIn<T>(T arg, T[] comparisonArray)
         {
             return comparisonArray == null || !comparisonArray.Contains(arg);
         }
+        // LINQ-friendly overload
+        public static Func<T, bool> IsNotIncludedIn<T>(T[] comparisonArray) => arg => IsNotIncludedIn(arg, comparisonArray);
 
         // Used on arrays of arrays (2D arrays). Returns true if all elements in the nested array pass the test
         public static bool EveryElement<T>(T[] array, Func<T, bool> condition)
         {
             return array != null && array.All(condition);
         }
+        // LINQ-friendly overload
+        public static Func<T[], bool> EveryElement<T>(Func<T, bool> condition) => array => EveryElement(array, condition);
     }
 }


### PR DESCRIPTION
Introduced LINQ-friendly overloads for IsIncludedIn, IsNotIncludedIn, and EveryElement in ArrayFilters.cs. Updated tests to cover new overloads for improved functional programming support.