### PR TITLE
Add LINQ-friendly date filter functions

### DIFF
--- a/src/csharp/FpFilters.Tests/DateFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/DateFiltersBddTests.cs
@@ -6,17 +6,21 @@ namespace FpFilters.DateFilters.BddTests
         private DateTime arg;
         private DateTime comparison;
         private bool result;
+        private Func<DateTime, bool> linqFilter;
 
         private void GivenDate(DateTime value) => arg = value;
         private void GivenComparison(DateTime value) => comparison = value;
-    private void WhenIsFutureDate() => result = FpFilters.DateFilters.DateFilters.IsFutureDate(arg, comparison);
-    private void WhenIsPastDate() => result = FpFilters.DateFilters.DateFilters.IsPastDate(arg, comparison);
+        private void WhenIsFutureDate() => result = FpFilters.DateFilters.DateFilters.IsFutureDate(arg, comparison);
+        private void WhenIsPastDate() => result = FpFilters.DateFilters.DateFilters.IsPastDate(arg, comparison);
         private void WhenIsSameDate() => result = FpFilters.DateFilters.DateFilters.IsSameDate(arg, comparison);
         private void WhenIsLeapYear() => result = FpFilters.DateFilters.DateFilters.IsLeapYear(arg);
         private void WhenIsMonday() => result = FpFilters.DateFilters.DateFilters.IsMonday(arg);
         private void WhenIsFriday() => result = FpFilters.DateFilters.DateFilters.IsFriday(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
+
+        private void GivenLinqFilter(Func<DateTime, bool> filter) => linqFilter = filter;
+        private void WhenApplyLinqFilter() => result = linqFilter(arg);
 
         [Scenario]
         public void Should_check_if_date_is_in_the_future()
@@ -29,6 +33,21 @@ namespace FpFilters.DateFilters.BddTests
                 _ => GivenDate(DateTime.Now.AddDays(-1)),
                 _ => GivenComparison(DateTime.Now),
                 _ => WhenIsFutureDate(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_if_date_is_in_the_future_linq()
+        {
+            var comparisonDate = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsFutureDate(comparisonDate)),
+                _ => GivenDate(comparisonDate.AddDays(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(comparisonDate.AddDays(-1)),
+                _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeFalse()
             );
         }
@@ -49,6 +68,21 @@ namespace FpFilters.DateFilters.BddTests
         }
 
         [Scenario]
+        public void Should_check_if_date_is_in_the_past_linq()
+        {
+            var comparisonDate = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsPastDate(comparisonDate)),
+                _ => GivenDate(comparisonDate.AddDays(-1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(comparisonDate.AddDays(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
         public void Should_check_if_dates_are_the_same()
         {
             var now = DateTime.Now;
@@ -60,6 +94,69 @@ namespace FpFilters.DateFilters.BddTests
                 _ => GivenDate(now),
                 _ => GivenComparison(now.AddDays(1)),
                 _ => WhenIsSameDate(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_if_dates_are_the_same_linq()
+        {
+            var now = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameDate(now)),
+                _ => GivenDate(now),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(now.AddDays(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_if_days_are_the_same_linq()
+        {
+            var now = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameDay(now)),
+                _ => GivenDate(now),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(now.AddMonths(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(now.AddDays(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_if_months_are_the_same_linq()
+        {
+            var now = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameMonth(now)),
+                _ => GivenDate(now),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(now.AddMonths(1)),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeFalse()
+            );
+        }
+
+        [Scenario]
+        public void Should_check_if_years_are_the_same_linq()
+        {
+            var now = DateTime.Now;
+            Runner.RunScenario(
+                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameYear(now)),
+                _ => GivenDate(now),
+                _ => WhenApplyLinqFilter(),
+                _ => ThenResultShouldBeTrue(),
+                _ => GivenDate(now.AddYears(1)),
+                _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeFalse()
             );
         }

--- a/src/csharp/FpFilters/DateFilters/DateFilters.cs
+++ b/src/csharp/FpFilters/DateFilters/DateFilters.cs
@@ -9,11 +9,22 @@ namespace FpFilters.DateFilters
         }
 
         public static bool IsFutureDate(DateTime date, DateTime comparison) => date > comparison;
+        public static Func<DateTime, bool> IsFutureDate(DateTime comparison) => date => IsFutureDate(date, comparison);
+
         public static bool IsPastDate(DateTime date, DateTime comparison) => date < comparison;
+        public static Func<DateTime, bool> IsPastDate(DateTime comparison) => date => IsPastDate(date, comparison);
+
         public static bool IsSameDate(DateTime date, DateTime comparison) => date.Date == comparison.Date;
+        public static Func<DateTime, bool> IsSameDate(DateTime comparison) => date => IsSameDate(date, comparison);
+
         public static bool IsSameDay(DateTime date, DateTime comparison) => date.Day == comparison.Day;
+        public static Func<DateTime, bool> IsSameDay(DateTime comparison) => date => IsSameDay(date, comparison);
+
         public static bool IsSameMonth(DateTime date, DateTime comparison) => date.Month == comparison.Month;
+        public static Func<DateTime, bool> IsSameMonth(DateTime comparison) => date => IsSameMonth(date, comparison);
+
         public static bool IsSameYear(DateTime date, DateTime comparison) => date.Year == comparison.Year;
+        public static Func<DateTime, bool> IsSameYear(DateTime comparison) => date => IsSameYear(date, comparison);
 
         public static bool IsWeekend(DateTime date)
         {


### PR DESCRIPTION
Introduces Func<DateTime, bool> overloads for date filter methods in DateFilters.cs to support LINQ usage. Adds corresponding BDD tests to verify the new LINQ filter functions for future, past, same date, same day, same month, and same year comparisons.