### PR TITLE
Add LINQ-style Is and IsNot filter delegates

### DIFF
--- a/src/csharp/FpFilters.Tests/MiscFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/MiscFiltersBddTests.cs
@@ -43,5 +43,29 @@ namespace FpFilters.MiscFilters.BddTests
                 _ => ThenResultShouldBeTrue() // 0 is not null for reference types
             );
         }
+
+        [Scenario]
+        public void Should_check_Is_linq()
+        {
+            // Use local variables for generic delegate and argument
+            var is42 = FpFilters.MiscFilters.MiscFilters.Is(42);
+            Xunit.Assert.True(is42(42));
+            Xunit.Assert.False(is42(43));
+            var isStr = FpFilters.MiscFilters.MiscFilters.Is("abc");
+            Xunit.Assert.True(isStr("abc"));
+            Xunit.Assert.False(isStr("def"));
+        }
+
+        [Scenario]
+        public void Should_check_IsNot_linq()
+        {
+            // Use local variables for generic delegate and argument
+            var isNot42 = FpFilters.MiscFilters.MiscFilters.IsNot(42);
+            Xunit.Assert.True(isNot42(43));
+            Xunit.Assert.False(isNot42(42));
+            var isNotStr = FpFilters.MiscFilters.MiscFilters.IsNot("abc");
+            Xunit.Assert.True(isNotStr("def"));
+            Xunit.Assert.False(isNotStr("abc"));
+        }
     }
 }

--- a/src/csharp/FpFilters/MiscFilters/MiscFilters.cs
+++ b/src/csharp/FpFilters/MiscFilters/MiscFilters.cs
@@ -4,9 +4,11 @@ namespace FpFilters.MiscFilters
     {
         // Returns true if the argument is equal to the comparison parameter
         public static bool Is<T>(T arg, T comparison) => Equals(arg, comparison);
+        public static Func<T, bool> Is<T>(T comparison) => arg => Is(arg, comparison);
 
         // Returns true if the argument is different from the comparison parameter
         public static bool IsNot<T>(T arg, T comparison) => !Equals(arg, comparison);
+        public static Func<T, bool> IsNot<T>(T comparison) => arg => IsNot(arg, comparison);
 
         // Returns true for all elements (identity function for filter)
         public static bool All() => true;


### PR DESCRIPTION
Introduced generic delegate overloads for Is and IsNot in MiscFilters to support LINQ-style usage. Added corresponding unit tests to verify correct behavior for both integer and string comparisons.