### PR TITLE
Add LINQ-style predicate helpers to ObjectFilters

### DIFF
--- a/src/csharp/FpFilters.Tests/ObjectFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/ObjectFiltersBddTests.cs
@@ -105,5 +105,133 @@ namespace FpFilters.ObjectFilters.BddTests
                 _ => ThenResultShouldBeFalse()
             );
         }
+
+        [Scenario]
+        public void Should_check_HasProp_linq()
+        {
+            var obj = new { Name = "Test", Value = 42 };
+            var hasName = FpFilters.ObjectFilters.ObjectFilters.HasProp("Name");
+            Xunit.Assert.True(hasName(obj));
+            var hasValue42 = FpFilters.ObjectFilters.ObjectFilters.HasProp("Value", 42);
+            Xunit.Assert.True(hasValue42(obj));
+            var hasValue43 = FpFilters.ObjectFilters.ObjectFilters.HasProp("Value", 43);
+            Xunit.Assert.False(hasValue43(obj));
+        }
+
+        [Scenario]
+        public void Should_check_HasProps_linq()
+        {
+            var obj = new { Name = "Test", Value = 42 };
+            var hasBoth = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" });
+            Xunit.Assert.True(hasBoth(obj));
+            var hasBothWithValues = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 42 });
+            Xunit.Assert.True(hasBothWithValues(obj));
+            var hasBothWithWrongValues = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
+            Xunit.Assert.False(hasBothWithWrongValues(obj));
+        }
+
+        [Scenario]
+        public void Should_check_HasSameProp_linq()
+        {
+            var obj1 = new { Name = "Test" };
+            var obj2 = new { Name = "Test" };
+            var obj3 = new { Name = "Other" };
+            var hasSameName = FpFilters.ObjectFilters.ObjectFilters.HasSameProp(obj2, "Name");
+            Xunit.Assert.True(hasSameName(obj1));
+            Xunit.Assert.False(hasSameName(obj3));
+        }
+
+        [Scenario]
+        public void Should_check_HasSameProps_linq()
+        {
+            var obj1 = new { Name = "Test", Value = 42 };
+            var obj2 = new { Name = "Test", Value = 42 };
+            var obj3 = new { Name = "Test", Value = 43 };
+            var hasSameBoth = FpFilters.ObjectFilters.ObjectFilters.HasSameProps(obj2, new[] { "Name", "Value" });
+            Xunit.Assert.True(hasSameBoth(obj1));
+            Xunit.Assert.False(hasSameBoth(obj3));
+        }
+
+        [Scenario]
+        public void Should_check_HasNotProp_linq()
+        {
+            var obj = new { Name = "Test", Value = 42 };
+            var hasNotName = FpFilters.ObjectFilters.ObjectFilters.HasNotProp("Name");
+            Xunit.Assert.False(hasNotName(obj));
+            var hasNotValue43 = FpFilters.ObjectFilters.ObjectFilters.HasNotProp("Value", 43);
+            Xunit.Assert.True(hasNotValue43(obj));
+        }
+
+        [Scenario]
+        public void Should_check_HasNotProps_linq()
+        {
+            var obj = new { Name = "Test", Value = 42 };
+            var hasNotBoth = FpFilters.ObjectFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" });
+            Xunit.Assert.False(hasNotBoth(obj));
+            var hasNotBothWithWrongValues = FpFilters.ObjectFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
+            Xunit.Assert.True(hasNotBothWithWrongValues(obj));
+        }
+
+        [Scenario]
+        public void Should_check_HasNotSameProp_linq()
+        {
+            var obj1 = new { Name = "Test" };
+            var obj2 = new { Name = "Test" };
+            var obj3 = new { Name = "Other" };
+            var hasNotSameName = FpFilters.ObjectFilters.ObjectFilters.HasNotSameProp(obj2, "Name");
+            Xunit.Assert.False(hasNotSameName(obj1));
+            Xunit.Assert.True(hasNotSameName(obj3));
+        }
+
+        [Scenario]
+        public void Should_check_HasNotSameProps_linq()
+        {
+            var obj1 = new { Name = "Test", Value = 42 };
+            var obj2 = new { Name = "Test", Value = 42 };
+            var obj3 = new { Name = "Test", Value = 43 };
+            var hasNotSameBoth = FpFilters.ObjectFilters.ObjectFilters.HasNotSameProps(obj2, new[] { "Name", "Value" });
+            Xunit.Assert.False(hasNotSameBoth(obj1));
+            Xunit.Assert.True(hasNotSameBoth(obj3));
+        }
+
+        [Scenario]
+        public void Should_check_IsEqualTo_linq()
+        {
+            var is42 = FpFilters.ObjectFilters.ObjectFilters.IsEqualTo(42);
+            Xunit.Assert.True(is42(42));
+            Xunit.Assert.False(is42(43));
+            var isStr = FpFilters.ObjectFilters.ObjectFilters.IsEqualTo("abc");
+            Xunit.Assert.True(isStr("abc"));
+            Xunit.Assert.False(isStr("def"));
+        }
+
+        [Scenario]
+        public void Should_check_IsNotEqualTo_linq()
+        {
+            var isNot42 = FpFilters.ObjectFilters.ObjectFilters.IsNotEqualTo(42);
+            Xunit.Assert.True(isNot42(43));
+            Xunit.Assert.False(isNot42(42));
+            var isNotStr = FpFilters.ObjectFilters.ObjectFilters.IsNotEqualTo("abc");
+            Xunit.Assert.True(isNotStr("def"));
+            Xunit.Assert.False(isNotStr("abc"));
+        }
+
+        [Scenario]
+        public void Should_check_IsReferenceEqual_linq()
+        {
+            var obj = new object();
+            var isRefEq = FpFilters.ObjectFilters.ObjectFilters.IsReferenceEqual(obj);
+            Xunit.Assert.True(isRefEq(obj));
+            Xunit.Assert.False(isRefEq(new object()));
+        }
+
+        [Scenario]
+        public void Should_check_IsReferenceNotEqual_linq()
+        {
+            var obj = new object();
+            var isRefNotEq = FpFilters.ObjectFilters.ObjectFilters.IsReferenceNotEqual(obj);
+            Xunit.Assert.False(isRefNotEq(obj));
+            Xunit.Assert.True(isRefNotEq(new object()));
+        }
     }
 }

--- a/src/csharp/FpFilters/ObjectFilters/ObjectFilters.cs
+++ b/src/csharp/FpFilters/ObjectFilters/ObjectFilters.cs
@@ -14,6 +14,7 @@ namespace FpFilters.ObjectFilters
                 return predicate(propertyValue!);
             return Equals(propertyValue, valueOrPredicate);
         }
+        public static Func<object, bool> HasProp(string propertyName, object? valueOrPredicate = null) => obj => HasProp(obj, propertyName, valueOrPredicate);
 
         // Checks if the object has all the specified properties, optionally with values
         public static bool HasProps(object obj, string[] propertyNames, object?[]? values = null)
@@ -26,6 +27,7 @@ namespace FpFilters.ObjectFilters
             }
             return true;
         }
+        public static Func<object, bool> HasProps(string[] propertyNames, object?[]? values = null) => obj => HasProps(obj, propertyNames, values);
 
         // Checks if the object has the same property value as a comparison object
         public static bool HasSameProp(object obj, object comparisonObject, string propertyName)
@@ -36,6 +38,7 @@ namespace FpFilters.ObjectFilters
             if (prop == null || compProp == null) return false;
             return Equals(prop.GetValue(obj), compProp.GetValue(comparisonObject));
         }
+        public static Func<object, bool> HasSameProp(object comparisonObject, string propertyName) => obj => HasSameProp(obj, comparisonObject, propertyName);
 
         // Checks if the object has all the same property values as a comparison object
         public static bool HasSameProps(object obj, object comparisonObject, string[] propertyNames)
@@ -46,18 +49,31 @@ namespace FpFilters.ObjectFilters
             }
             return true;
         }
+        public static Func<object, bool> HasSameProps(object comparisonObject, string[] propertyNames) => obj => HasSameProps(obj, comparisonObject, propertyNames);
 
         // Negative checks
         public static bool HasNotProp(object obj, string propertyName, object? valueOrPredicate = null) => !HasProp(obj, propertyName, valueOrPredicate);
+        public static Func<object, bool> HasNotProp(string propertyName, object? valueOrPredicate = null) => obj => HasNotProp(obj, propertyName, valueOrPredicate);
+
         public static bool HasNotProps(object obj, string[] propertyNames, object?[]? values = null) => !HasProps(obj, propertyNames, values);
+        public static Func<object, bool> HasNotProps(string[] propertyNames, object?[]? values = null) => obj => HasNotProps(obj, propertyNames, values);
+
         public static bool HasNotSameProp(object obj, object comparisonObject, string propertyName) => !HasSameProp(obj, comparisonObject, propertyName);
+        public static Func<object, bool> HasNotSameProp(object comparisonObject, string propertyName) => obj => HasNotSameProp(obj, comparisonObject, propertyName);
+
         public static bool HasNotSameProps(object obj, object comparisonObject, string[] propertyNames) => !HasSameProps(obj, comparisonObject, propertyNames);
+        public static Func<object, bool> HasNotSameProps(object comparisonObject, string[] propertyNames) => obj => HasNotSameProps(obj, comparisonObject, propertyNames);
+
         // BDD test support methods
         public static bool IsNull(object? obj) => obj == null;
         public static bool IsNotNull(object? obj) => obj != null;
         public static bool IsEqualTo(object? obj, object? comparison) => Equals(obj, comparison);
+        public static Func<object?, bool> IsEqualTo(object? comparison) => obj => IsEqualTo(obj, comparison);
         public static bool IsNotEqualTo(object? obj, object? comparison) => !Equals(obj, comparison);
+        public static Func<object?, bool> IsNotEqualTo(object? comparison) => obj => IsNotEqualTo(obj, comparison);
         public static bool IsReferenceEqual(object? obj, object? comparison) => ReferenceEquals(obj, comparison);
+        public static Func<object?, bool> IsReferenceEqual(object? comparison) => obj => IsReferenceEqual(obj, comparison);
         public static bool IsReferenceNotEqual(object? obj, object? comparison) => !ReferenceEquals(obj, comparison);
+        public static Func<object?, bool> IsReferenceNotEqual(object? comparison) => obj => IsReferenceNotEqual(obj, comparison);
     }
 }


### PR DESCRIPTION
Introduces LINQ-style predicate functions (e.g., HasProp, HasProps, HasSameProp, HasNotProp, IsEqualTo, etc.) to ObjectFilters for easier functional composition. Adds corresponding BDD tests to verify the new predicate helpers.