### PR TITLE
Add LINQ-style type filter functions and tests

### DIFF
--- a/src/csharp/FpFilters.Tests/TypeFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/TypeFiltersBddTests.cs
@@ -129,5 +129,49 @@ namespace FpFilters.TypeFilters.BddTests
                 _ => ThenResultShouldBeFalse()
             );
         }
+
+        [Scenario]
+        public void Should_check_IsSameTypeAs_linq()
+        {
+            var isSameTypeAsInt = FpFilters.TypeFilters.TypeFilters.IsSameTypeAs(42);
+            Xunit.Assert.True(isSameTypeAsInt(123));
+            Xunit.Assert.False(isSameTypeAsInt("string"));
+            var isSameTypeAsStr = FpFilters.TypeFilters.TypeFilters.IsSameTypeAs("abc");
+            Xunit.Assert.True(isSameTypeAsStr("def"));
+            Xunit.Assert.False(isSameTypeAsStr(42));
+        }
+
+        [Scenario]
+        public void Should_check_IsNotSameTypeAs_linq()
+        {
+            var isNotSameTypeAsInt = FpFilters.TypeFilters.TypeFilters.IsNotSameTypeAs(42);
+            Xunit.Assert.False(isNotSameTypeAsInt(123));
+            Xunit.Assert.True(isNotSameTypeAsInt("string"));
+            var isNotSameTypeAsStr = FpFilters.TypeFilters.TypeFilters.IsNotSameTypeAs("abc");
+            Xunit.Assert.False(isNotSameTypeAsStr("def"));
+            Xunit.Assert.True(isNotSameTypeAsStr(42));
+        }
+
+        [Scenario]
+        public void Should_check_IsOfType_linq()
+        {
+            var isOfTypeInt = FpFilters.TypeFilters.TypeFilters.IsOfType(typeof(int));
+            Xunit.Assert.True(isOfTypeInt(42));
+            Xunit.Assert.False(isOfTypeInt("string"));
+            var isOfTypeStr = FpFilters.TypeFilters.TypeFilters.IsOfType(typeof(string));
+            Xunit.Assert.True(isOfTypeStr("abc"));
+            Xunit.Assert.False(isOfTypeStr(42));
+        }
+
+        [Scenario]
+        public void Should_check_IsNotOfType_linq()
+        {
+            var isNotOfTypeInt = FpFilters.TypeFilters.TypeFilters.IsNotOfType(typeof(int));
+            Xunit.Assert.False(isNotOfTypeInt(42));
+            Xunit.Assert.True(isNotOfTypeInt("string"));
+            var isNotOfTypeStr = FpFilters.TypeFilters.TypeFilters.IsNotOfType(typeof(string));
+            Xunit.Assert.False(isNotOfTypeStr("abc"));
+            Xunit.Assert.True(isNotOfTypeStr(42));
+        }
     }
 }

--- a/src/csharp/FpFilters/TypeFilters/TypeFilters.cs
+++ b/src/csharp/FpFilters/TypeFilters/TypeFilters.cs
@@ -52,15 +52,19 @@ namespace FpFilters.TypeFilters
 
         // Returns true if the argument is of the same type as comparison
         public static bool IsSameTypeAs<T>(object? arg, T comparison) => arg?.GetType() == comparison?.GetType();
+        public static Func<object?, bool> IsSameTypeAs<T>(T comparison) => arg => IsSameTypeAs(arg, comparison);
 
         // Returns true if the argument is not of the same type as comparison
         public static bool IsNotSameTypeAs<T>(object? arg, T comparison) => arg?.GetType() != comparison?.GetType();
+        public static Func<object?, bool> IsNotSameTypeAs<T>(T comparison) => arg => IsNotSameTypeAs(arg, comparison);
 
         // Returns true if the argument is of the specified type
         public static bool IsOfType(object? arg, Type type) => arg != null && arg.GetType() == type;
+        public static Func<object?, bool> IsOfType(Type type) => arg => IsOfType(arg, type);
 
         // Returns true if the argument is not of the specified type
         public static bool IsNotOfType(object? arg, Type type) => arg == null || arg.GetType() != type;
+        public static Func<object?, bool> IsNotOfType(Type type) => arg => IsNotOfType(arg, type);
 
         // Returns true if the argument is an instance of the specified class
         public static bool IsInstanceOf<T>(object? arg) => arg is T;


### PR DESCRIPTION
Introduced LINQ-style higher-order functions for type filters: IsSameTypeAs, IsNotSameTypeAs, IsOfType, and IsNotOfType. Added corresponding BDD tests to verify their behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added predicate-based type-check filters, enabling functional composition for checking whether a value is of a given type, the same type as another value, or their negations.

* **Tests**
  * Expanded test coverage with new scenarios validating the behavior of the added type-check predicates across matching and non-matching inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->