### PR TITLE
Name spaces

### DIFF
--- a/src/csharp/FpFilters.Tests/ArrayFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/ArrayFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ArrayFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription(
         "ArrayFilters: BDD scenarios for array filter functions.")]
@@ -8,12 +8,12 @@ namespace FpFilters.ArrayFilters.BddTests
         private bool result;
 
         private void GivenArray(params int[] values) => arr = values;
-        private void WhenIsIncludedIn(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsIncludedIn(value, arr);
-        private void WhenIsIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsIncludedIn(arr)(value);
-        private void WhenIsNotIncludedIn(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsNotIncludedIn(value, arr);
-        private void WhenIsNotIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.ArrayFilters.IsNotIncludedIn(arr)(value);
-        private void WhenEveryElement(Func<int, bool> condition) => result = FpFilters.ArrayFilters.ArrayFilters.EveryElement(arr, condition);
-        private void WhenEveryElement_Linq(Func<int, bool> condition) => result = FpFilters.ArrayFilters.ArrayFilters.EveryElement(condition)(arr);
+        private void WhenIsIncludedIn(int value) => result = FpFilters.ArrayFilters.IsIncludedIn(value, arr);
+        private void WhenIsIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.IsIncludedIn(arr)(value);
+        private void WhenIsNotIncludedIn(int value) => result = FpFilters.ArrayFilters.IsNotIncludedIn(value, arr);
+        private void WhenIsNotIncludedIn_Linq(int value) => result = FpFilters.ArrayFilters.IsNotIncludedIn(arr)(value);
+        private void WhenEveryElement(Func<int, bool> condition) => result = FpFilters.ArrayFilters.EveryElement(arr, condition);
+        private void WhenEveryElement_Linq(Func<int, bool> condition) => result = FpFilters.ArrayFilters.EveryElement(condition)(arr);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 

--- a/src/csharp/FpFilters.Tests/ArrayFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/ArrayFiltersTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ArrayFilters.Tests
+namespace FpFilters.Tests
 {
     public class ArrayFiltersTests
     {
@@ -6,24 +6,24 @@ namespace FpFilters.ArrayFilters.Tests
         public void IsIncludedIn_ReturnsTrueIfIncluded()
         {
             int[] arr = { 1, 2, 3 };
-            Assert.True(ArrayFilters.IsIncludedIn(2, arr));
-            Assert.False(ArrayFilters.IsIncludedIn(4, arr));
+            Assert.True(FpFilters.ArrayFilters.IsIncludedIn(2, arr));
+            Assert.False(FpFilters.ArrayFilters.IsIncludedIn(4, arr));
         }
 
         [Fact]
         public void IsNotIncludedIn_ReturnsTrueIfNotIncluded()
         {
             int[] arr = { 1, 2, 3 };
-            Assert.True(ArrayFilters.IsNotIncludedIn(4, arr));
-            Assert.False(ArrayFilters.IsNotIncludedIn(2, arr));
+            Assert.True(FpFilters.ArrayFilters.IsNotIncludedIn(4, arr));
+            Assert.False(FpFilters.ArrayFilters.IsNotIncludedIn(2, arr));
         }
 
         [Fact]
         public void EveryElement_ReturnsTrueIfAllPassCondition()
         {
             int[] arr = { 2, 4, 6 };
-            Assert.True(ArrayFilters.EveryElement(arr, x => x % 2 == 0));
-            Assert.False(ArrayFilters.EveryElement(arr, x => x > 4));
+            Assert.True(FpFilters.ArrayFilters.EveryElement(arr, x => x % 2 == 0));
+            Assert.False(FpFilters.ArrayFilters.EveryElement(arr, x => x > 4));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/BooleanFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/BooleanFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.BooleanFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("BooleanFilters: BDD scenarios for boolean filter functions.")]
     public class BooleanFiltersFeature : FeatureFixture
@@ -7,10 +7,10 @@ namespace FpFilters.BooleanFilters.BddTests
         private bool result;
 
         private void GivenBool(bool value) => arg = value;
-        private void WhenIsTrue() => result = FpFilters.BooleanFilters.BooleanFilters.IsTrue(arg);
-        private void WhenIsFalse() => result = FpFilters.BooleanFilters.BooleanFilters.IsFalse(arg);
-        private void WhenIsTruthy() => result = FpFilters.BooleanFilters.BooleanFilters.IsTruthy(arg);
-        private void WhenIsFalsey() => result = FpFilters.BooleanFilters.BooleanFilters.IsFalsey(arg);
+        private void WhenIsTrue() => result = FpFilters.BooleanFilters.IsTrue(arg);
+        private void WhenIsFalse() => result = FpFilters.BooleanFilters.IsFalse(arg);
+        private void WhenIsTruthy() => result = FpFilters.BooleanFilters.IsTruthy(arg);
+        private void WhenIsFalsey() => result = FpFilters.BooleanFilters.IsFalsey(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -69,31 +69,31 @@ namespace FpFilters.BooleanFilters.BddTests
         [Scenario]
         public void Should_check_various_types_for_truthy_and_falsey()
         {
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(null));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(""));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy("abc"));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(0));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(42));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(0.0));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(3.14));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(new int[] {}));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(new int[] { 1 }));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(new System.Collections.Generic.List<int>()));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(new System.Collections.Generic.List<int> { 1 }));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsTruthy(new object()));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(null));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(""));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy("abc"));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(0));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy(42));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(0.0));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy(3.14));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(new int[] {}));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy(new int[] { 1 }));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsTruthy(new System.Collections.Generic.List<int>()));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy(new System.Collections.Generic.List<int> { 1 }));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsTruthy(new object()));
 
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(null));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(""));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey("abc"));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(0));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(42));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(0.0));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(3.14));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(new int[] {}));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(new int[] { 1 }));
-            Xunit.Assert.True(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(new System.Collections.Generic.List<int>()));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(new System.Collections.Generic.List<int> { 1 }));
-            Xunit.Assert.False(FpFilters.BooleanFilters.BooleanFilters.IsFalsey(new object()));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(null));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(""));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey("abc"));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(0));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey(42));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(0.0));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey(3.14));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(new int[] {}));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey(new int[] { 1 }));
+            Xunit.Assert.True(FpFilters.BooleanFilters.IsFalsey(new System.Collections.Generic.List<int>()));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey(new System.Collections.Generic.List<int> { 1 }));
+            Xunit.Assert.False(FpFilters.BooleanFilters.IsFalsey(new object()));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/BooleanFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/BooleanFiltersTests.cs
@@ -1,49 +1,49 @@
-namespace FpFilters.BooleanFilters.Tests
+namespace FpFilters.Tests
 {
     public class BooleanFiltersTests
     {
         [Fact]
         public void IsTrue_ReturnsTrueForTrue()
         {
-            Assert.True(BooleanFilters.IsTrue(true));
-            Assert.False(BooleanFilters.IsTrue(false));
+            Assert.True(FpFilters.BooleanFilters.IsTrue(true));
+            Assert.False(FpFilters.BooleanFilters.IsTrue(false));
         }
 
         [Fact]
         public void IsFalse_ReturnsTrueForFalse()
         {
-            Assert.True(BooleanFilters.IsFalse(false));
-            Assert.False(BooleanFilters.IsFalse(true));
+            Assert.True(FpFilters.BooleanFilters.IsFalse(false));
+            Assert.False(FpFilters.BooleanFilters.IsFalse(true));
         }
 
         [Fact]
         public void IsTruthy_WorksForVariousTypes()
         {
-            Assert.True(BooleanFilters.IsTruthy(true));
-            Assert.False(BooleanFilters.IsTruthy(false));
-            Assert.True(BooleanFilters.IsTruthy("abc"));
-            Assert.False(BooleanFilters.IsTruthy(""));
-            Assert.True(BooleanFilters.IsTruthy(1));
-            Assert.False(BooleanFilters.IsTruthy(0));
-            Assert.True(BooleanFilters.IsTruthy(1.0));
-            Assert.False(BooleanFilters.IsTruthy(0.0));
-            Assert.True(BooleanFilters.IsTruthy(new List<int> { 1 }));
-            Assert.False(BooleanFilters.IsTruthy(new List<int>()));
+            Assert.True(FpFilters.BooleanFilters.IsTruthy(true));
+            Assert.False(FpFilters.BooleanFilters.IsTruthy(false));
+            Assert.True(FpFilters.BooleanFilters.IsTruthy("abc"));
+            Assert.False(FpFilters.BooleanFilters.IsTruthy(""));
+            Assert.True(FpFilters.BooleanFilters.IsTruthy(1));
+            Assert.False(FpFilters.BooleanFilters.IsTruthy(0));
+            Assert.True(FpFilters.BooleanFilters.IsTruthy(1.0));
+            Assert.False(FpFilters.BooleanFilters.IsTruthy(0.0));
+            Assert.True(FpFilters.BooleanFilters.IsTruthy(new List<int> { 1 }));
+            Assert.False(FpFilters.BooleanFilters.IsTruthy(new List<int>()));
         }
 
         [Fact]
         public void IsFalsey_WorksForVariousTypes()
         {
-            Assert.False(BooleanFilters.IsFalsey(true));
-            Assert.True(BooleanFilters.IsFalsey(false));
-            Assert.False(BooleanFilters.IsFalsey("abc"));
-            Assert.True(BooleanFilters.IsFalsey(""));
-            Assert.False(BooleanFilters.IsFalsey(1));
-            Assert.True(BooleanFilters.IsFalsey(0));
-            Assert.False(BooleanFilters.IsFalsey(1.0));
-            Assert.True(BooleanFilters.IsFalsey(0.0));
-            Assert.False(BooleanFilters.IsFalsey(new List<int> { 1 }));
-            Assert.True(BooleanFilters.IsFalsey(new List<int>()));
+            Assert.False(FpFilters.BooleanFilters.IsFalsey(true));
+            Assert.True(FpFilters.BooleanFilters.IsFalsey(false));
+            Assert.False(FpFilters.BooleanFilters.IsFalsey("abc"));
+            Assert.True(FpFilters.BooleanFilters.IsFalsey(""));
+            Assert.False(FpFilters.BooleanFilters.IsFalsey(1));
+            Assert.True(FpFilters.BooleanFilters.IsFalsey(0));
+            Assert.False(FpFilters.BooleanFilters.IsFalsey(1.0));
+            Assert.True(FpFilters.BooleanFilters.IsFalsey(0.0));
+            Assert.False(FpFilters.BooleanFilters.IsFalsey(new List<int> { 1 }));
+            Assert.True(FpFilters.BooleanFilters.IsFalsey(new List<int>()));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/DateFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/DateFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.DateFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("DateFilters: BDD scenarios for date filter functions.")]
     public class DateFiltersFeature : FeatureFixture
@@ -10,12 +10,12 @@ namespace FpFilters.DateFilters.BddTests
 
         private void GivenDate(DateTime value) => arg = value;
         private void GivenComparison(DateTime value) => comparison = value;
-        private void WhenIsFutureDate() => result = FpFilters.DateFilters.DateFilters.IsFutureDate(arg, comparison);
-        private void WhenIsPastDate() => result = FpFilters.DateFilters.DateFilters.IsPastDate(arg, comparison);
-        private void WhenIsSameDate() => result = FpFilters.DateFilters.DateFilters.IsSameDate(arg, comparison);
-        private void WhenIsLeapYear() => result = FpFilters.DateFilters.DateFilters.IsLeapYear(arg);
-        private void WhenIsMonday() => result = FpFilters.DateFilters.DateFilters.IsMonday(arg);
-        private void WhenIsFriday() => result = FpFilters.DateFilters.DateFilters.IsFriday(arg);
+        private void WhenIsFutureDate() => result = FpFilters.DateFilters.IsFutureDate(arg, comparison);
+        private void WhenIsPastDate() => result = FpFilters.DateFilters.IsPastDate(arg, comparison);
+        private void WhenIsSameDate() => result = FpFilters.DateFilters.IsSameDate(arg, comparison);
+        private void WhenIsLeapYear() => result = FpFilters.DateFilters.IsLeapYear(arg);
+        private void WhenIsMonday() => result = FpFilters.DateFilters.IsMonday(arg);
+        private void WhenIsFriday() => result = FpFilters.DateFilters.IsFriday(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -42,7 +42,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var comparisonDate = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsFutureDate(comparisonDate)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsFutureDate(comparisonDate)),
                 _ => GivenDate(comparisonDate.AddDays(1)),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -72,7 +72,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var comparisonDate = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsPastDate(comparisonDate)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsPastDate(comparisonDate)),
                 _ => GivenDate(comparisonDate.AddDays(-1)),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -103,7 +103,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var now = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameDate(now)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsSameDate(now)),
                 _ => GivenDate(now),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -118,7 +118,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var now = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameDay(now)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsSameDay(now)),
                 _ => GivenDate(now),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -136,7 +136,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var now = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameMonth(now)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsSameMonth(now)),
                 _ => GivenDate(now),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -151,7 +151,7 @@ namespace FpFilters.DateFilters.BddTests
         {
             var now = DateTime.Now;
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.DateFilters.DateFilters.IsSameYear(now)),
+                _ => GivenLinqFilter(FpFilters.DateFilters.IsSameYear(now)),
                 _ => GivenDate(now),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),

--- a/src/csharp/FpFilters.Tests/DateFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/DateFiltersTests.cs
@@ -1,30 +1,30 @@
-namespace FpFilters.DateFilters.Tests
+namespace FpFilters.Tests
 {
     public class DateFiltersTests
     {
         [Fact]
         public void IsLeapYear_WorksCorrectly()
         {
-            Assert.True(DateFilters.IsLeapYear(new DateTime(2020, 1, 1)));
-            Assert.False(DateFilters.IsLeapYear(new DateTime(2021, 1, 1)));
-            Assert.True(DateFilters.IsLeapYear(new DateTime(2000, 1, 1)));
-            Assert.False(DateFilters.IsLeapYear(new DateTime(1900, 1, 1)));
+            Assert.True(FpFilters.DateFilters.IsLeapYear(new DateTime(2020, 1, 1)));
+            Assert.False(FpFilters.DateFilters.IsLeapYear(new DateTime(2021, 1, 1)));
+            Assert.True(FpFilters.DateFilters.IsLeapYear(new DateTime(2000, 1, 1)));
+            Assert.False(FpFilters.DateFilters.IsLeapYear(new DateTime(1900, 1, 1)));
         }
 
         [Fact]
         public void IsFutureDate_WorksCorrectly()
         {
             var now = DateTime.Now;
-            Assert.True(DateFilters.IsFutureDate(now.AddDays(1), now));
-            Assert.False(DateFilters.IsFutureDate(now.AddDays(-1), now));
+            Assert.True(FpFilters.DateFilters.IsFutureDate(now.AddDays(1), now));
+            Assert.False(FpFilters.DateFilters.IsFutureDate(now.AddDays(-1), now));
         }
 
         [Fact]
         public void IsPastDate_WorksCorrectly()
         {
             var now = DateTime.Now;
-            Assert.True(DateFilters.IsPastDate(now.AddDays(-1), now));
-            Assert.False(DateFilters.IsPastDate(now.AddDays(1), now));
+            Assert.True(FpFilters.DateFilters.IsPastDate(now.AddDays(-1), now));
+            Assert.False(FpFilters.DateFilters.IsPastDate(now.AddDays(1), now));
         }
 
         [Fact]
@@ -33,8 +33,8 @@ namespace FpFilters.DateFilters.Tests
             var d1 = new DateTime(2025, 9, 7);
             var d2 = new DateTime(2025, 9, 7);
             var d3 = new DateTime(2025, 9, 8);
-            Assert.True(DateFilters.IsSameDate(d1, d2));
-            Assert.False(DateFilters.IsSameDate(d1, d3));
+            Assert.True(FpFilters.DateFilters.IsSameDate(d1, d2));
+            Assert.False(FpFilters.DateFilters.IsSameDate(d1, d3));
         }
 
         [Fact]
@@ -42,8 +42,8 @@ namespace FpFilters.DateFilters.Tests
         {
             var d1 = new DateTime(2025, 9, 7);
             var d2 = new DateTime(2025, 8, 7);
-            Assert.True(DateFilters.IsSameDay(d1, d2));
-            Assert.False(DateFilters.IsSameDay(d1, new DateTime(2025, 9, 8)));
+            Assert.True(FpFilters.DateFilters.IsSameDay(d1, d2));
+            Assert.False(FpFilters.DateFilters.IsSameDay(d1, new DateTime(2025, 9, 8)));
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace FpFilters.DateFilters.Tests
         {
             var d1 = new DateTime(2025, 9, 7);
             var d2 = new DateTime(2025, 9, 8);
-            Assert.True(DateFilters.IsSameMonth(d1, d2));
-            Assert.False(DateFilters.IsSameMonth(d1, new DateTime(2025, 8, 7)));
+            Assert.True(FpFilters.DateFilters.IsSameMonth(d1, d2));
+            Assert.False(FpFilters.DateFilters.IsSameMonth(d1, new DateTime(2025, 8, 7)));
         }
 
         [Fact]
@@ -60,35 +60,35 @@ namespace FpFilters.DateFilters.Tests
         {
             var d1 = new DateTime(2025, 9, 7);
             var d2 = new DateTime(2025, 1, 1);
-            Assert.True(DateFilters.IsSameYear(d1, d2));
-            Assert.False(DateFilters.IsSameYear(d1, new DateTime(2024, 9, 7)));
+            Assert.True(FpFilters.DateFilters.IsSameYear(d1, d2));
+            Assert.False(FpFilters.DateFilters.IsSameYear(d1, new DateTime(2024, 9, 7)));
         }
 
         [Fact]
         public void IsWeekend_WorksCorrectly()
         {
-            Assert.True(DateFilters.IsWeekend(new DateTime(2025, 9, 6))); // Saturday
-            Assert.True(DateFilters.IsWeekend(new DateTime(2025, 9, 7))); // Sunday
-            Assert.False(DateFilters.IsWeekend(new DateTime(2025, 9, 8))); // Monday
+            Assert.True(FpFilters.DateFilters.IsWeekend(new DateTime(2025, 9, 6))); // Saturday
+            Assert.True(FpFilters.DateFilters.IsWeekend(new DateTime(2025, 9, 7))); // Sunday
+            Assert.False(FpFilters.DateFilters.IsWeekend(new DateTime(2025, 9, 8))); // Monday
         }
 
         [Fact]
         public void IsWorkingWeek_WorksCorrectly()
         {
-            Assert.True(DateFilters.IsWorkingWeek(new DateTime(2025, 9, 8))); // Monday
-            Assert.False(DateFilters.IsWorkingWeek(new DateTime(2025, 9, 7))); // Sunday
+            Assert.True(FpFilters.DateFilters.IsWorkingWeek(new DateTime(2025, 9, 8))); // Monday
+            Assert.False(FpFilters.DateFilters.IsWorkingWeek(new DateTime(2025, 9, 7))); // Sunday
         }
 
         [Fact]
         public void DayOfWeekChecks_WorkCorrectly()
         {
-            Assert.True(DateFilters.IsMonday(new DateTime(2025, 9, 8)));
-            Assert.True(DateFilters.IsTuesday(new DateTime(2025, 9, 9)));
-            Assert.True(DateFilters.IsWednesday(new DateTime(2025, 9, 10)));
-            Assert.True(DateFilters.IsThursday(new DateTime(2025, 9, 11)));
-            Assert.True(DateFilters.IsFriday(new DateTime(2025, 9, 12)));
-            Assert.True(DateFilters.IsSaturday(new DateTime(2025, 9, 13)));
-            Assert.True(DateFilters.IsSunday(new DateTime(2025, 9, 14)));
+            Assert.True(FpFilters.DateFilters.IsMonday(new DateTime(2025, 9, 8)));
+            Assert.True(FpFilters.DateFilters.IsTuesday(new DateTime(2025, 9, 9)));
+            Assert.True(FpFilters.DateFilters.IsWednesday(new DateTime(2025, 9, 10)));
+            Assert.True(FpFilters.DateFilters.IsThursday(new DateTime(2025, 9, 11)));
+            Assert.True(FpFilters.DateFilters.IsFriday(new DateTime(2025, 9, 12)));
+            Assert.True(FpFilters.DateFilters.IsSaturday(new DateTime(2025, 9, 13)));
+            Assert.True(FpFilters.DateFilters.IsSunday(new DateTime(2025, 9, 14)));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/LengthFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/LengthFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.LengthFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("LengthFilters: BDD scenarios for length filter functions.")]
     public class LengthFiltersFeature : FeatureFixture
@@ -11,10 +11,10 @@ namespace FpFilters.LengthFilters.BddTests
 
         private void GivenString(string value) => arg = value;
         private void GivenComparison(int value) => comparison = value;
-        private void WhenIsLengthEqualTo() => result = FpFilters.LengthFilters.LengthFilters.IsLengthEqualTo(arg, comparison);
-        private void WhenIsLengthGreaterThan() => result = FpFilters.LengthFilters.LengthFilters.IsLengthGreaterThan(arg, comparison);
-        private void WhenIsLengthLessThan() => result = FpFilters.LengthFilters.LengthFilters.IsLengthLessThan(arg, comparison);
-        private void WhenIsLengthZero() => result = FpFilters.LengthFilters.LengthFilters.IsLengthZero(arg);
+        private void WhenIsLengthEqualTo() => result = FpFilters.LengthFilters.IsLengthEqualTo(arg, comparison);
+        private void WhenIsLengthGreaterThan() => result = FpFilters.LengthFilters.IsLengthGreaterThan(arg, comparison);
+        private void WhenIsLengthLessThan() => result = FpFilters.LengthFilters.IsLengthLessThan(arg, comparison);
+        private void WhenIsLengthZero() => result = FpFilters.LengthFilters.IsLengthZero(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -81,53 +81,53 @@ namespace FpFilters.LengthFilters.BddTests
         [Scenario]
         public void Should_check_empty_and_not_empty_for_various_types()
         {
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.IsEmpty(""));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty("abc"));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.IsEmpty(new int[] {}));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty(new int[] { 1, 2 }));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.IsEmpty(new System.Collections.Generic.List<int>()));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty(new System.Collections.Generic.List<int> { 1 }));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty(null));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsNotEmpty(""));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.IsNotEmpty("abc"));
+            Xunit.Assert.True(FpFilters.LengthFilters.IsEmpty(""));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty("abc"));
+            Xunit.Assert.True(FpFilters.LengthFilters.IsEmpty(new int[] {}));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty(new int[] { 1, 2 }));
+            Xunit.Assert.True(FpFilters.LengthFilters.IsEmpty(new System.Collections.Generic.List<int>()));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty(new System.Collections.Generic.List<int> { 1 }));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty(null));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsNotEmpty(""));
+            Xunit.Assert.True(FpFilters.LengthFilters.IsNotEmpty("abc"));
         }
 
         [Scenario]
         public void Should_check_has_length_and_variants_for_various_types()
         {
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLength("abc", 3));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength("abc", 2));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLength(new int[] { 1, 2 }, 2));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMin("abc", 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMin("a", 2));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax("abc", 3));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax("abcd", 3));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthBetween("abc", 2, 3));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthBetween("abc", 4, 5));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLength("abc", 3));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength("abc", 2));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLength(new int[] { 1, 2 }, 2));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMin("abc", 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMin("a", 2));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax("abc", 3));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax("abcd", 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthBetween("abc", 2, 3));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthBetween("abc", 4, 5));
         }
 
         [Scenario]
         public void Should_check_has_not_length_and_variants()
         {
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasNotLength("abc", 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasNotLength("abc", 3));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasNotLengthMin("a", 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasNotLengthMin("abc", 2));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasNotLengthMax("abcd", 3));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasNotLengthMax("abc", 3));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasNotLengthBetween("abc", 4, 5));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasNotLengthBetween("abc", 2, 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasNotLength("abc", 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasNotLength("abc", 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasNotLengthMin("a", 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasNotLengthMin("abc", 2));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasNotLengthMax("abcd", 3));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasNotLengthMax("abc", 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasNotLengthBetween("abc", 4, 5));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasNotLengthBetween("abc", 2, 3));
         }
 
         [Scenario]
         public void Should_check_length_property_on_custom_object()
         {
             var custom = new { Length = 5 };
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLength(custom, 5));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength(custom, 4));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMin(custom, 5));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(custom, 5));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthBetween(custom, 5, 5));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLength(custom, 5));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength(custom, 4));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMin(custom, 5));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(custom, 5));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthBetween(custom, 5, 5));
         }
 
         [Scenario]
@@ -135,24 +135,24 @@ namespace FpFilters.LengthFilters.BddTests
         {
             object? nullObj = null;
             object noLength = new { Value = 42 };
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength(nullObj, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMin(nullObj, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(nullObj, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthBetween(nullObj, 1, 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength(noLength, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMin(noLength, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(noLength, 1));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthBetween(noLength, 1, 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength(nullObj, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMin(nullObj, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(nullObj, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthBetween(nullObj, 1, 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength(noLength, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMin(noLength, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(noLength, 1));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthBetween(noLength, 1, 2));
         }
 
         [Scenario]
         public void Should_check_length_methods_with_null_string()
         {
             string? nullStr = null;
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsLengthEqualTo(nullStr, 0));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsLengthGreaterThan(nullStr, 0));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsLengthLessThan(nullStr, 0));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsLengthZero(nullStr));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsLengthEqualTo(nullStr, 0));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsLengthGreaterThan(nullStr, 0));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsLengthLessThan(nullStr, 0));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsLengthZero(nullStr));
         }
 
         [Scenario]
@@ -164,24 +164,24 @@ namespace FpFilters.LengthFilters.BddTests
             var objectWithoutLength = new { Name = "test" };
             
             // Test IsEmpty with reflection path
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.IsEmpty(customEmptyLength));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty(customNonZeroLength));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.IsEmpty(objectWithoutLength));
+            Xunit.Assert.True(FpFilters.LengthFilters.IsEmpty(customEmptyLength));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty(customNonZeroLength));
+            Xunit.Assert.False(FpFilters.LengthFilters.IsEmpty(objectWithoutLength));
             
             // Test HasLength with reflection path
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLength(customNonZeroLength, 3));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength(customNonZeroLength, 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLength(objectWithoutLength, 1));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLength(customNonZeroLength, 3));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength(customNonZeroLength, 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLength(objectWithoutLength, 1));
             
             // Test HasLengthMin with reflection path
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMin(customNonZeroLength, 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMin(customNonZeroLength, 4));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMin(objectWithoutLength, 1));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMin(customNonZeroLength, 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMin(customNonZeroLength, 4));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMin(objectWithoutLength, 1));
             
             // Test HasLengthMax with reflection path
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(customNonZeroLength, 4));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(customNonZeroLength, 2));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(objectWithoutLength, 5));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(customNonZeroLength, 4));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(customNonZeroLength, 2));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(objectWithoutLength, 5));
         }
 
         [Scenario]
@@ -192,21 +192,21 @@ namespace FpFilters.LengthFilters.BddTests
             var array = new int[] { 1, 2, 3, 4 };
             
             // Test HasLengthMax with ICollection (List)
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(list, 3));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(list, 5));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(list, 2));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(list, 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(list, 5));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(list, 2));
             
             // Test HasLengthMax with ICollection (Array)
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(array, 4));
-            Xunit.Assert.True(FpFilters.LengthFilters.LengthFilters.HasLengthMax(array, 6));
-            Xunit.Assert.False(FpFilters.LengthFilters.LengthFilters.HasLengthMax(array, 3));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(array, 4));
+            Xunit.Assert.True(FpFilters.LengthFilters.HasLengthMax(array, 6));
+            Xunit.Assert.False(FpFilters.LengthFilters.HasLengthMax(array, 3));
         }
 
         [Scenario]
         public void Should_check_HasLength_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasLength(3)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasLength(3)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -220,7 +220,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasLengthMin_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasLengthMin(2)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasLengthMin(2)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -234,7 +234,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasLengthMax_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasLengthMax(3)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasLengthMax(3)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -248,7 +248,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasLengthBetween_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasLengthBetween(2, 3)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasLengthBetween(2, 3)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -265,7 +265,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasNotLength_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasNotLength(2)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasNotLength(2)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -279,7 +279,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasNotLengthMin_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasNotLengthMin(2)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasNotLengthMin(2)),
                 _ => GivenString("a"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -293,7 +293,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasNotLengthMax_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasNotLengthMax(3)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasNotLengthMax(3)),
                 _ => GivenString("abcd"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -307,7 +307,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_HasNotLengthBetween_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqFilter(FpFilters.LengthFilters.LengthFilters.HasNotLengthBetween(2, 3)),
+                _ => GivenLinqFilter(FpFilters.LengthFilters.HasNotLengthBetween(2, 3)),
                 _ => GivenString("a"),
                 _ => WhenApplyLinqFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -321,7 +321,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_IsLengthEqualTo_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqStringFilter(FpFilters.LengthFilters.LengthFilters.IsLengthEqualTo(3)),
+                _ => GivenLinqStringFilter(FpFilters.LengthFilters.IsLengthEqualTo(3)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqStringFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -335,7 +335,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_IsLengthGreaterThan_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqStringFilter(FpFilters.LengthFilters.LengthFilters.IsLengthGreaterThan(2)),
+                _ => GivenLinqStringFilter(FpFilters.LengthFilters.IsLengthGreaterThan(2)),
                 _ => GivenString("abc"),
                 _ => WhenApplyLinqStringFilter(),
                 _ => ThenResultShouldBeTrue(),
@@ -349,7 +349,7 @@ namespace FpFilters.LengthFilters.BddTests
         public void Should_check_IsLengthLessThan_linq()
         {
             Runner.RunScenario(
-                _ => GivenLinqStringFilter(FpFilters.LengthFilters.LengthFilters.IsLengthLessThan(3)),
+                _ => GivenLinqStringFilter(FpFilters.LengthFilters.IsLengthLessThan(3)),
                 _ => GivenString("ab"),
                 _ => WhenApplyLinqStringFilter(),
                 _ => ThenResultShouldBeTrue(),

--- a/src/csharp/FpFilters.Tests/LengthFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/LengthFiltersTests.cs
@@ -1,84 +1,84 @@
-namespace FpFilters.LengthFilters.Tests
+namespace FpFilters.Tests
 {
     public class LengthFiltersTests
     {
         [Fact]
         public void IsEmpty_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.IsEmpty(""));
-            Assert.False(LengthFilters.IsEmpty("abc"));
-            Assert.True(LengthFilters.IsEmpty(new List<int>()));
-            Assert.False(LengthFilters.IsEmpty(new List<int> { 1 }));
+            Assert.True(FpFilters.LengthFilters.IsEmpty(""));
+            Assert.False(FpFilters.LengthFilters.IsEmpty("abc"));
+            Assert.True(FpFilters.LengthFilters.IsEmpty(new List<int>()));
+            Assert.False(FpFilters.LengthFilters.IsEmpty(new List<int> { 1 }));
         }
 
         [Fact]
         public void IsNotEmpty_WorksForStringAndCollection()
         {
-            Assert.False(LengthFilters.IsNotEmpty(""));
-            Assert.True(LengthFilters.IsNotEmpty("abc"));
-            Assert.False(LengthFilters.IsNotEmpty(new List<int>()));
-            Assert.True(LengthFilters.IsNotEmpty(new List<int> { 1 }));
+            Assert.False(FpFilters.LengthFilters.IsNotEmpty(""));
+            Assert.True(FpFilters.LengthFilters.IsNotEmpty("abc"));
+            Assert.False(FpFilters.LengthFilters.IsNotEmpty(new List<int>()));
+            Assert.True(FpFilters.LengthFilters.IsNotEmpty(new List<int> { 1 }));
         }
 
         [Fact]
         public void HasLength_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasLength("abc", 3));
-            Assert.False(LengthFilters.HasLength("abc", 2));
-            Assert.True(LengthFilters.HasLength(new List<int> { 1, 2 }, 2));
-            Assert.False(LengthFilters.HasLength(new List<int> { 1, 2 }, 3));
+            Assert.True(FpFilters.LengthFilters.HasLength("abc", 3));
+            Assert.False(FpFilters.LengthFilters.HasLength("abc", 2));
+            Assert.True(FpFilters.LengthFilters.HasLength(new List<int> { 1, 2 }, 2));
+            Assert.False(FpFilters.LengthFilters.HasLength(new List<int> { 1, 2 }, 3));
         }
 
         [Fact]
         public void HasLengthMin_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasLengthMin("abc", 2));
-            Assert.False(LengthFilters.HasLengthMin("abc", 4));
-            Assert.True(LengthFilters.HasLengthMin(new List<int> { 1, 2 }, 2));
-            Assert.False(LengthFilters.HasLengthMin(new List<int> { 1, 2 }, 3));
+            Assert.True(FpFilters.LengthFilters.HasLengthMin("abc", 2));
+            Assert.False(FpFilters.LengthFilters.HasLengthMin("abc", 4));
+            Assert.True(FpFilters.LengthFilters.HasLengthMin(new List<int> { 1, 2 }, 2));
+            Assert.False(FpFilters.LengthFilters.HasLengthMin(new List<int> { 1, 2 }, 3));
         }
 
         [Fact]
         public void HasLengthMax_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasLengthMax("abc", 3));
-            Assert.True(LengthFilters.HasLengthMax("abc", 4));
-            Assert.False(LengthFilters.HasLengthMax("abc", 2));
+            Assert.True(FpFilters.LengthFilters.HasLengthMax("abc", 3));
+            Assert.True(FpFilters.LengthFilters.HasLengthMax("abc", 4));
+            Assert.False(FpFilters.LengthFilters.HasLengthMax("abc", 2));
         }
 
         [Fact]
         public void HasLengthBetween_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasLengthBetween("abc", 2, 3));
-            Assert.False(LengthFilters.HasLengthBetween("abc", 4, 5));
+            Assert.True(FpFilters.LengthFilters.HasLengthBetween("abc", 2, 3));
+            Assert.False(FpFilters.LengthFilters.HasLengthBetween("abc", 4, 5));
         }
 
         [Fact]
         public void HasNotLength_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasNotLength("abc", 2));
-            Assert.False(LengthFilters.HasNotLength("abc", 3));
+            Assert.True(FpFilters.LengthFilters.HasNotLength("abc", 2));
+            Assert.False(FpFilters.LengthFilters.HasNotLength("abc", 3));
         }
 
         [Fact]
         public void HasNotLengthMin_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasNotLengthMin("abc", 4));
-            Assert.False(LengthFilters.HasNotLengthMin("abc", 2));
+            Assert.True(FpFilters.LengthFilters.HasNotLengthMin("abc", 4));
+            Assert.False(FpFilters.LengthFilters.HasNotLengthMin("abc", 2));
         }
 
         [Fact]
         public void HasNotLengthMax_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasNotLengthMax("abc", 2));
-            Assert.False(LengthFilters.HasNotLengthMax("abc", 3));
+            Assert.True(FpFilters.LengthFilters.HasNotLengthMax("abc", 2));
+            Assert.False(FpFilters.LengthFilters.HasNotLengthMax("abc", 3));
         }
 
         [Fact]
         public void HasNotLengthBetween_WorksForStringAndCollection()
         {
-            Assert.True(LengthFilters.HasNotLengthBetween("abc", 4, 5));
-            Assert.False(LengthFilters.HasNotLengthBetween("abc", 2, 3));
+            Assert.True(FpFilters.LengthFilters.HasNotLengthBetween("abc", 4, 5));
+            Assert.False(FpFilters.LengthFilters.HasNotLengthBetween("abc", 2, 3));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/MiscFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/MiscFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.MiscFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("MiscFilters: BDD scenarios for miscellaneous filter functions.")]
     public class MiscFiltersFeature : FeatureFixture
@@ -7,8 +7,8 @@ namespace FpFilters.MiscFilters.BddTests
         private bool result;
 
         private void GivenValue(object? value) => arg = value;
-        private void WhenIsNullOrDefault() => result = FpFilters.MiscFilters.MiscFilters.IsNullOrDefault(arg);
-        private void WhenIsNotNullOrDefault() => result = FpFilters.MiscFilters.MiscFilters.IsNotNullOrDefault(arg);
+        private void WhenIsNullOrDefault() => result = FpFilters.MiscFilters.IsNullOrDefault(arg);
+        private void WhenIsNotNullOrDefault() => result = FpFilters.MiscFilters.IsNotNullOrDefault(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -48,10 +48,10 @@ namespace FpFilters.MiscFilters.BddTests
         public void Should_check_Is_linq()
         {
             // Use local variables for generic delegate and argument
-            var is42 = FpFilters.MiscFilters.MiscFilters.Is(42);
+            var is42 = FpFilters.MiscFilters.Is(42);
             Xunit.Assert.True(is42(42));
             Xunit.Assert.False(is42(43));
-            var isStr = FpFilters.MiscFilters.MiscFilters.Is("abc");
+            var isStr = FpFilters.MiscFilters.Is("abc");
             Xunit.Assert.True(isStr("abc"));
             Xunit.Assert.False(isStr("def"));
         }
@@ -60,10 +60,10 @@ namespace FpFilters.MiscFilters.BddTests
         public void Should_check_IsNot_linq()
         {
             // Use local variables for generic delegate and argument
-            var isNot42 = FpFilters.MiscFilters.MiscFilters.IsNot(42);
+            var isNot42 = FpFilters.MiscFilters.IsNot(42);
             Xunit.Assert.True(isNot42(43));
             Xunit.Assert.False(isNot42(42));
-            var isNotStr = FpFilters.MiscFilters.MiscFilters.IsNot("abc");
+            var isNotStr = FpFilters.MiscFilters.IsNot("abc");
             Xunit.Assert.True(isNotStr("def"));
             Xunit.Assert.False(isNotStr("abc"));
         }

--- a/src/csharp/FpFilters.Tests/MiscFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/MiscFiltersTests.cs
@@ -1,32 +1,32 @@
-namespace FpFilters.MiscFilters.Tests
+namespace FpFilters.Tests
 {
     public class MiscFiltersTests
     {
         [Fact]
         public void Is_ReturnsTrueForEqual()
         {
-            Assert.True(MiscFilters.Is(5, 5));
-            Assert.True(MiscFilters.Is("abc", "abc"));
-            Assert.False(MiscFilters.Is(5, 6));
+            Assert.True(FpFilters.MiscFilters.Is(5, 5));
+            Assert.True(FpFilters.MiscFilters.Is("abc", "abc"));
+            Assert.False(FpFilters.MiscFilters.Is(5, 6));
         }
 
         [Fact]
         public void IsNot_ReturnsTrueForNotEqual()
         {
-            Assert.True(MiscFilters.IsNot(5, 6));
-            Assert.False(MiscFilters.IsNot(5, 5));
+            Assert.True(FpFilters.MiscFilters.IsNot(5, 6));
+            Assert.False(FpFilters.MiscFilters.IsNot(5, 5));
         }
 
         [Fact]
         public void All_ReturnsTrue()
         {
-            Assert.True(MiscFilters.All());
+            Assert.True(FpFilters.MiscFilters.All());
         }
 
         [Fact]
         public void None_ReturnsFalse()
         {
-            Assert.False(MiscFilters.None());
+            Assert.False(FpFilters.MiscFilters.None());
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/NumberFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/NumberFiltersBddTests.cs
@@ -1,4 +1,5 @@
-namespace FpFilters.NumberFilters.BddTests
+using FpFilters;
+namespace FpFilters.BddTests
 {
 	[FeatureDescription("NumberFilters: BDD scenarios for number filter functions.")]
 	public class NumberFiltersFeature : FeatureFixture
@@ -11,29 +12,29 @@ namespace FpFilters.NumberFilters.BddTests
 		private void GivenNumber(double value) => arg = value;
 		private void GivenInt(int value) => intArg = value;
 		private void GivenComparison(double value) => comparison = value;
-		private void WhenIsEven() => filtered = FpFilters.NumberFilters.NumberFilters.IsEven(intArg);
-		private void WhenIsOdd() => filtered = FpFilters.NumberFilters.NumberFilters.IsOdd(intArg);
-		private void WhenIsPositive() => filtered = FpFilters.NumberFilters.NumberFilters.IsPositive(arg);
-		private void WhenIsNegative() => filtered = FpFilters.NumberFilters.NumberFilters.IsNegative(arg);
-		private void WhenIsZero() => filtered = FpFilters.NumberFilters.NumberFilters.IsZero(arg);
-		private void WhenIsGreaterThan() => filtered = FpFilters.NumberFilters.NumberFilters.IsGreaterThan(arg, comparison);
-		private void WhenIsLessThan() => filtered = FpFilters.NumberFilters.NumberFilters.IsLowerThan(arg, comparison);
-		private void WhenIsEqualTo() => filtered = FpFilters.NumberFilters.NumberFilters.IsLowerOrEqualTo(arg, comparison) && FpFilters.NumberFilters.NumberFilters.IsGreaterOrEqualTo(arg, comparison);
-		private void WhenIsNotEqualTo() => filtered = !(FpFilters.NumberFilters.NumberFilters.IsLowerOrEqualTo(arg, comparison) && FpFilters.NumberFilters.NumberFilters.IsGreaterOrEqualTo(arg, comparison));
+		private void WhenIsEven() => filtered = NumberFilters.IsEven(intArg);
+		private void WhenIsOdd() => filtered = NumberFilters.IsOdd(intArg);
+		private void WhenIsPositive() => filtered = NumberFilters.IsPositive(arg);
+		private void WhenIsNegative() => filtered = NumberFilters.IsNegative(arg);
+		private void WhenIsZero() => filtered = NumberFilters.IsZero(arg);
+		private void WhenIsGreaterThan() => filtered = NumberFilters.IsGreaterThan(arg, comparison);
+		private void WhenIsLessThan() => filtered = NumberFilters.IsLowerThan(arg, comparison);
+		private void WhenIsEqualTo() => filtered = NumberFilters.IsLowerOrEqualTo(arg, comparison) && NumberFilters.IsGreaterOrEqualTo(arg, comparison);
+		private void WhenIsNotEqualTo() => filtered = !(NumberFilters.IsLowerOrEqualTo(arg, comparison) && NumberFilters.IsGreaterOrEqualTo(arg, comparison));
 		private void WhenIsFinite() => filtered = !double.IsInfinity(arg) && !double.IsNaN(arg);
 		private void WhenIsInfinite() => filtered = double.IsInfinity(arg);
 		private void WhenIsNaN() => filtered = double.IsNaN(arg);
 		private void ThenResultShouldBeTrue() => Xunit.Assert.True(filtered);
 		private void ThenResultShouldBeFalse() => Xunit.Assert.False(filtered);
-		private void WhenIsMultipleOfLinq() => filtered = FpFilters.NumberFilters.NumberFilters.IsMultipleOf(3)(intArg);
-		private void WhenIsLowerThanLinq() => filtered = FpFilters.NumberFilters.NumberFilters.IsLowerThan(comparison)(arg);
-		private void WhenIsLowerOrEqualToLinq() => filtered = FpFilters.NumberFilters.NumberFilters.IsLowerOrEqualTo(comparison)(arg);
-		private void WhenIsGreaterThanLinq() => filtered = FpFilters.NumberFilters.NumberFilters.IsGreaterThan(comparison)(arg);
-		private void WhenIsGreaterOrEqualToLinq() => filtered = FpFilters.NumberFilters.NumberFilters.IsGreaterOrEqualTo(comparison)(arg);
-		private void WhenIsBetweenExcludingMinLinq(double min, double max) => filtered = FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingMin(min, max)(arg);
-		private void WhenIsBetweenExcludingMaxLinq(double min, double max) => filtered = FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingMax(min, max)(arg);
-		private void WhenIsBetweenExcludingBoundariesLinq(double min, double max) => filtered = FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingBoundaries(min, max)(arg);
-		private void WhenIsBetweenLinq(double min, double max) => filtered = FpFilters.NumberFilters.NumberFilters.IsBetween(min, max)(arg);
+		private void WhenIsMultipleOfLinq() => filtered = NumberFilters.IsMultipleOf(3)(intArg);
+		private void WhenIsLowerThanLinq() => filtered = NumberFilters.IsLowerThan(comparison)(arg);
+		private void WhenIsLowerOrEqualToLinq() => filtered = NumberFilters.IsLowerOrEqualTo(comparison)(arg);
+		private void WhenIsGreaterThanLinq() => filtered = NumberFilters.IsGreaterThan(comparison)(arg);
+		private void WhenIsGreaterOrEqualToLinq() => filtered = NumberFilters.IsGreaterOrEqualTo(comparison)(arg);
+		private void WhenIsBetweenExcludingMinLinq(double min, double max) => filtered = NumberFilters.IsBetweenExcludingMin(min, max)(arg);
+		private void WhenIsBetweenExcludingMaxLinq(double min, double max) => filtered = NumberFilters.IsBetweenExcludingMax(min, max)(arg);
+		private void WhenIsBetweenExcludingBoundariesLinq(double min, double max) => filtered = NumberFilters.IsBetweenExcludingBoundaries(min, max)(arg);
+		private void WhenIsBetweenLinq(double min, double max) => filtered = NumberFilters.IsBetween(min, max)(arg);
 
 		[Scenario]
 		public void Should_check_if_number_is_even()
@@ -334,7 +335,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsBetweenExcludingMin_Linq_edge_cases()
 		{
 			var numbers = new[] { 2.0, 3.0, 4.0, 5.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingMin(3.0, 5.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsBetweenExcludingMin(3.0, 5.0)).ToArray();
 			Xunit.Assert.Equal(new[] { 4.0, 5.0 }, result);
 		}
 
@@ -342,7 +343,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsBetweenExcludingMax_Linq_edge_cases()
 		{
 			var numbers = new[] { 2.0, 3.0, 4.0, 5.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingMax(3.0, 5.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsBetweenExcludingMax(3.0, 5.0)).ToArray();
 			Xunit.Assert.Equal(new[] { 3.0, 4.0 }, result);
 		}
 
@@ -350,7 +351,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsBetweenExcludingBoundaries_Linq_edge_cases()
 		{
 			var numbers = new[] { 2.0, 3.0, 4.0, 5.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsBetweenExcludingBoundaries(3.0, 5.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsBetweenExcludingBoundaries(3.0, 5.0)).ToArray();
 			Xunit.Assert.Equal(new[] { 4.0 }, result);
 		}
 
@@ -358,7 +359,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsBetween_Linq_edge_cases()
 		{
 			var numbers = new[] { 2.0, 3.0, 4.0, 5.0, 6.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsBetween(3.0, 5.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsBetween(3.0, 5.0)).ToArray();
 			Xunit.Assert.Equal(new[] { 3.0, 4.0, 5.0 }, result);
 		}
 
@@ -366,7 +367,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsLowerThan_Linq_all_false()
 		{
 			var numbers = new[] { 3.0, 4.0, 5.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsLowerThan(2.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsLowerThan(2.0)).ToArray();
 			Xunit.Assert.Empty(result);
 		}
 
@@ -374,7 +375,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsGreaterThan_Linq_all_true()
 		{
 			var numbers = new[] { 4.0, 5.0, 6.0 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsGreaterThan(3.0)).ToArray();
+			var result = numbers.Where(NumberFilters.IsGreaterThan(3.0)).ToArray();
 			Xunit.Assert.Equal(new[] { 4.0, 5.0, 6.0 }, result);
 		}
 
@@ -382,7 +383,7 @@ namespace FpFilters.NumberFilters.BddTests
 		public void Should_filter_collection_with_IsMultipleOf_Linq_none()
 		{
 			var numbers = new[] { 2, 4, 5 };
-			var result = numbers.Where(FpFilters.NumberFilters.NumberFilters.IsMultipleOf(3)).ToArray();
+			var result = numbers.Where(NumberFilters.IsMultipleOf(3)).ToArray();
 			Xunit.Assert.Empty(result);
 		}
 	}

--- a/src/csharp/FpFilters.Tests/NumberFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/NumberFiltersTests.cs
@@ -1,4 +1,5 @@
-namespace FpFilters.NumberFilters.Tests
+using FpFilters;
+namespace FpFilters.Tests
 {
     public class NumberFiltersTests
     {

--- a/src/csharp/FpFilters.Tests/ObjectFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/ObjectFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ObjectFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("ObjectFilters: BDD scenarios for object filter functions.")]
     public class ObjectFiltersFeature : FeatureFixture
@@ -9,12 +9,12 @@ namespace FpFilters.ObjectFilters.BddTests
 
         private void GivenObject(object? value) => arg = value;
         private void GivenComparison(object value) => comparison = value;
-        private void WhenIsNull() => result = FpFilters.ObjectFilters.ObjectFilters.IsNull(arg);
-        private void WhenIsNotNull() => result = FpFilters.ObjectFilters.ObjectFilters.IsNotNull(arg);
-        private void WhenIsEqualTo() => result = FpFilters.ObjectFilters.ObjectFilters.IsEqualTo(arg, comparison);
-        private void WhenIsNotEqualTo() => result = FpFilters.ObjectFilters.ObjectFilters.IsNotEqualTo(arg, comparison);
-        private void WhenIsReferenceEqual() => result = FpFilters.ObjectFilters.ObjectFilters.IsReferenceEqual(arg, comparison);
-        private void WhenIsReferenceNotEqual() => result = FpFilters.ObjectFilters.ObjectFilters.IsReferenceNotEqual(arg, comparison);
+        private void WhenIsNull() => result = FpFilters.ObjectFilters.IsNull(arg);
+        private void WhenIsNotNull() => result = FpFilters.ObjectFilters.IsNotNull(arg);
+        private void WhenIsEqualTo() => result = FpFilters.ObjectFilters.IsEqualTo(arg, comparison);
+        private void WhenIsNotEqualTo() => result = FpFilters.ObjectFilters.IsNotEqualTo(arg, comparison);
+        private void WhenIsReferenceEqual() => result = FpFilters.ObjectFilters.IsReferenceEqual(arg, comparison);
+        private void WhenIsReferenceNotEqual() => result = FpFilters.ObjectFilters.IsReferenceNotEqual(arg, comparison);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -110,11 +110,11 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_HasProp_linq()
         {
             var obj = new { Name = "Test", Value = 42 };
-            var hasName = FpFilters.ObjectFilters.ObjectFilters.HasProp("Name");
+            var hasName = FpFilters.ObjectFilters.HasProp("Name");
             Xunit.Assert.True(hasName(obj));
-            var hasValue42 = FpFilters.ObjectFilters.ObjectFilters.HasProp("Value", 42);
+            var hasValue42 = FpFilters.ObjectFilters.HasProp("Value", 42);
             Xunit.Assert.True(hasValue42(obj));
-            var hasValue43 = FpFilters.ObjectFilters.ObjectFilters.HasProp("Value", 43);
+            var hasValue43 = FpFilters.ObjectFilters.HasProp("Value", 43);
             Xunit.Assert.False(hasValue43(obj));
         }
 
@@ -122,11 +122,11 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_HasProps_linq()
         {
             var obj = new { Name = "Test", Value = 42 };
-            var hasBoth = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" });
+            var hasBoth = FpFilters.ObjectFilters.HasProps(new[] { "Name", "Value" });
             Xunit.Assert.True(hasBoth(obj));
-            var hasBothWithValues = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 42 });
+            var hasBothWithValues = FpFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 42 });
             Xunit.Assert.True(hasBothWithValues(obj));
-            var hasBothWithWrongValues = FpFilters.ObjectFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
+            var hasBothWithWrongValues = FpFilters.ObjectFilters.HasProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
             Xunit.Assert.False(hasBothWithWrongValues(obj));
         }
 
@@ -136,7 +136,7 @@ namespace FpFilters.ObjectFilters.BddTests
             var obj1 = new { Name = "Test" };
             var obj2 = new { Name = "Test" };
             var obj3 = new { Name = "Other" };
-            var hasSameName = FpFilters.ObjectFilters.ObjectFilters.HasSameProp(obj2, "Name");
+            var hasSameName = FpFilters.ObjectFilters.HasSameProp(obj2, "Name");
             Xunit.Assert.True(hasSameName(obj1));
             Xunit.Assert.False(hasSameName(obj3));
         }
@@ -147,7 +147,7 @@ namespace FpFilters.ObjectFilters.BddTests
             var obj1 = new { Name = "Test", Value = 42 };
             var obj2 = new { Name = "Test", Value = 42 };
             var obj3 = new { Name = "Test", Value = 43 };
-            var hasSameBoth = FpFilters.ObjectFilters.ObjectFilters.HasSameProps(obj2, new[] { "Name", "Value" });
+            var hasSameBoth = FpFilters.ObjectFilters.HasSameProps(obj2, new[] { "Name", "Value" });
             Xunit.Assert.True(hasSameBoth(obj1));
             Xunit.Assert.False(hasSameBoth(obj3));
         }
@@ -156,9 +156,9 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_HasNotProp_linq()
         {
             var obj = new { Name = "Test", Value = 42 };
-            var hasNotName = FpFilters.ObjectFilters.ObjectFilters.HasNotProp("Name");
+            var hasNotName = FpFilters.ObjectFilters.HasNotProp("Name");
             Xunit.Assert.False(hasNotName(obj));
-            var hasNotValue43 = FpFilters.ObjectFilters.ObjectFilters.HasNotProp("Value", 43);
+            var hasNotValue43 = FpFilters.ObjectFilters.HasNotProp("Value", 43);
             Xunit.Assert.True(hasNotValue43(obj));
         }
 
@@ -166,9 +166,9 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_HasNotProps_linq()
         {
             var obj = new { Name = "Test", Value = 42 };
-            var hasNotBoth = FpFilters.ObjectFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" });
+            var hasNotBoth = FpFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" });
             Xunit.Assert.False(hasNotBoth(obj));
-            var hasNotBothWithWrongValues = FpFilters.ObjectFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
+            var hasNotBothWithWrongValues = FpFilters.ObjectFilters.HasNotProps(new[] { "Name", "Value" }, new object?[] { "Test", 43 });
             Xunit.Assert.True(hasNotBothWithWrongValues(obj));
         }
 
@@ -178,7 +178,7 @@ namespace FpFilters.ObjectFilters.BddTests
             var obj1 = new { Name = "Test" };
             var obj2 = new { Name = "Test" };
             var obj3 = new { Name = "Other" };
-            var hasNotSameName = FpFilters.ObjectFilters.ObjectFilters.HasNotSameProp(obj2, "Name");
+            var hasNotSameName = FpFilters.ObjectFilters.HasNotSameProp(obj2, "Name");
             Xunit.Assert.False(hasNotSameName(obj1));
             Xunit.Assert.True(hasNotSameName(obj3));
         }
@@ -189,7 +189,7 @@ namespace FpFilters.ObjectFilters.BddTests
             var obj1 = new { Name = "Test", Value = 42 };
             var obj2 = new { Name = "Test", Value = 42 };
             var obj3 = new { Name = "Test", Value = 43 };
-            var hasNotSameBoth = FpFilters.ObjectFilters.ObjectFilters.HasNotSameProps(obj2, new[] { "Name", "Value" });
+            var hasNotSameBoth = FpFilters.ObjectFilters.HasNotSameProps(obj2, new[] { "Name", "Value" });
             Xunit.Assert.False(hasNotSameBoth(obj1));
             Xunit.Assert.True(hasNotSameBoth(obj3));
         }
@@ -197,10 +197,10 @@ namespace FpFilters.ObjectFilters.BddTests
         [Scenario]
         public void Should_check_IsEqualTo_linq()
         {
-            var is42 = FpFilters.ObjectFilters.ObjectFilters.IsEqualTo(42);
+            var is42 = FpFilters.ObjectFilters.IsEqualTo(42);
             Xunit.Assert.True(is42(42));
             Xunit.Assert.False(is42(43));
-            var isStr = FpFilters.ObjectFilters.ObjectFilters.IsEqualTo("abc");
+            var isStr = FpFilters.ObjectFilters.IsEqualTo("abc");
             Xunit.Assert.True(isStr("abc"));
             Xunit.Assert.False(isStr("def"));
         }
@@ -208,10 +208,10 @@ namespace FpFilters.ObjectFilters.BddTests
         [Scenario]
         public void Should_check_IsNotEqualTo_linq()
         {
-            var isNot42 = FpFilters.ObjectFilters.ObjectFilters.IsNotEqualTo(42);
+            var isNot42 = FpFilters.ObjectFilters.IsNotEqualTo(42);
             Xunit.Assert.True(isNot42(43));
             Xunit.Assert.False(isNot42(42));
-            var isNotStr = FpFilters.ObjectFilters.ObjectFilters.IsNotEqualTo("abc");
+            var isNotStr = FpFilters.ObjectFilters.IsNotEqualTo("abc");
             Xunit.Assert.True(isNotStr("def"));
             Xunit.Assert.False(isNotStr("abc"));
         }
@@ -220,7 +220,7 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_IsReferenceEqual_linq()
         {
             var obj = new object();
-            var isRefEq = FpFilters.ObjectFilters.ObjectFilters.IsReferenceEqual(obj);
+            var isRefEq = FpFilters.ObjectFilters.IsReferenceEqual(obj);
             Xunit.Assert.True(isRefEq(obj));
             Xunit.Assert.False(isRefEq(new object()));
         }
@@ -229,7 +229,7 @@ namespace FpFilters.ObjectFilters.BddTests
         public void Should_check_IsReferenceNotEqual_linq()
         {
             var obj = new object();
-            var isRefNotEq = FpFilters.ObjectFilters.ObjectFilters.IsReferenceNotEqual(obj);
+            var isRefNotEq = FpFilters.ObjectFilters.IsReferenceNotEqual(obj);
             Xunit.Assert.False(isRefNotEq(obj));
             Xunit.Assert.True(isRefNotEq(new object()));
         }

--- a/src/csharp/FpFilters.Tests/ObjectFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/ObjectFiltersTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ObjectFilters.Tests
+namespace FpFilters.Tests
 {
     public class ObjectFiltersTests
     {
@@ -13,33 +13,33 @@ namespace FpFilters.ObjectFilters.Tests
         public void HasProp_ReturnsTrueForExistingProp()
         {
             var obj = new TestObj { Id = 1, Name = "Test", Flag = true };
-            Assert.True(ObjectFilters.HasProp(obj, "Id"));
-            Assert.True(ObjectFilters.HasProp(obj, "Name"));
-            Assert.False(ObjectFilters.HasProp(obj, "NonExistent"));
+            Assert.True(FpFilters.ObjectFilters.HasProp(obj, "Id"));
+            Assert.True(FpFilters.ObjectFilters.HasProp(obj, "Name"));
+            Assert.False(FpFilters.ObjectFilters.HasProp(obj, "NonExistent"));
         }
 
         [Fact]
         public void HasProp_ReturnsTrueForMatchingValue()
         {
             var obj = new TestObj { Id = 1, Name = "Test", Flag = true };
-            Assert.True(ObjectFilters.HasProp(obj, "Id", 1));
-            Assert.False(ObjectFilters.HasProp(obj, "Id", 2));
+            Assert.True(FpFilters.ObjectFilters.HasProp(obj, "Id", 1));
+            Assert.False(FpFilters.ObjectFilters.HasProp(obj, "Id", 2));
         }
 
         [Fact]
         public void HasProp_ReturnsTrueForPredicate()
         {
             var obj = new TestObj { Id = 1, Name = "Test", Flag = true };
-            Assert.True(ObjectFilters.HasProp(obj, "Id", (object v) => (int)v == 1));
-            Assert.False(ObjectFilters.HasProp(obj, "Id", (object v) => (int)v == 2));
+            Assert.True(FpFilters.ObjectFilters.HasProp(obj, "Id", (object v) => (int)v == 1));
+            Assert.False(FpFilters.ObjectFilters.HasProp(obj, "Id", (object v) => (int)v == 2));
         }
 
         [Fact]
         public void HasProps_ReturnsTrueForAllProps()
         {
             var obj = new TestObj { Id = 1, Name = "Test", Flag = true };
-            Assert.True(ObjectFilters.HasProps(obj, new[] { "Id", "Name" }, new object?[] { 1, "Test" }));
-            Assert.False(ObjectFilters.HasProps(obj, new[] { "Id", "Name" }, new object?[] { 2, "Test" }));
+            Assert.True(FpFilters.ObjectFilters.HasProps(obj, new[] { "Id", "Name" }, new object?[] { 1, "Test" }));
+            Assert.False(FpFilters.ObjectFilters.HasProps(obj, new[] { "Id", "Name" }, new object?[] { 2, "Test" }));
         }
 
         [Fact]
@@ -47,10 +47,10 @@ namespace FpFilters.ObjectFilters.Tests
         {
             var obj1 = new TestObj { Id = 1, Name = "Test" };
             var obj2 = new TestObj { Id = 1, Name = "Test" };
-            Assert.True(ObjectFilters.HasSameProp(obj1, obj2, "Id"));
-            Assert.True(ObjectFilters.HasSameProp(obj1, obj2, "Name"));
+            Assert.True(FpFilters.ObjectFilters.HasSameProp(obj1, obj2, "Id"));
+            Assert.True(FpFilters.ObjectFilters.HasSameProp(obj1, obj2, "Name"));
             obj2.Id = 2;
-            Assert.False(ObjectFilters.HasSameProp(obj1, obj2, "Id"));
+            Assert.False(FpFilters.ObjectFilters.HasSameProp(obj1, obj2, "Id"));
         }
 
         [Fact]
@@ -58,9 +58,9 @@ namespace FpFilters.ObjectFilters.Tests
         {
             var obj1 = new TestObj { Id = 1, Name = "Test" };
             var obj2 = new TestObj { Id = 1, Name = "Test" };
-            Assert.True(ObjectFilters.HasSameProps(obj1, obj2, new[] { "Id", "Name" }));
+            Assert.True(FpFilters.ObjectFilters.HasSameProps(obj1, obj2, new[] { "Id", "Name" }));
             obj2.Id = 2;
-            Assert.False(ObjectFilters.HasSameProps(obj1, obj2, new[] { "Id", "Name" }));
+            Assert.False(FpFilters.ObjectFilters.HasSameProps(obj1, obj2, new[] { "Id", "Name" }));
         }
 
         [Fact]
@@ -68,10 +68,10 @@ namespace FpFilters.ObjectFilters.Tests
         {
             var obj1 = new TestObj { Id = 1, Name = "Test" };
             var obj2 = new TestObj { Id = 2, Name = "Test2" };
-            Assert.True(ObjectFilters.HasNotProp(obj1, "Id", 2));
-            Assert.True(ObjectFilters.HasNotProps(obj1, new[] { "Id", "Name" }, new object?[] { 2, "Test2" }));
-            Assert.True(ObjectFilters.HasNotSameProp(obj1, obj2, "Id"));
-            Assert.True(ObjectFilters.HasNotSameProps(obj1, obj2, new[] { "Id", "Name" }));
+            Assert.True(FpFilters.ObjectFilters.HasNotProp(obj1, "Id", 2));
+            Assert.True(FpFilters.ObjectFilters.HasNotProps(obj1, new[] { "Id", "Name" }, new object?[] { 2, "Test2" }));
+            Assert.True(FpFilters.ObjectFilters.HasNotSameProp(obj1, obj2, "Id"));
+            Assert.True(FpFilters.ObjectFilters.HasNotSameProps(obj1, obj2, new[] { "Id", "Name" }));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/PositionFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/PositionFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.PositionFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("PositionFilters: BDD scenarios for position filter functions.")]
     public class PositionFiltersFeature : FeatureFixture
@@ -9,9 +9,9 @@ namespace FpFilters.PositionFilters.BddTests
 
         private void GivenPosition(int value) => arg = value;
         private void GivenComparison(int value) => comparison = value;
-        private void WhenIsFirst() => result = FpFilters.PositionFilters.PositionFilters.IsFirst(arg);
-        private void WhenIsLast(int length) => result = FpFilters.PositionFilters.PositionFilters.IsLast(arg, length);
-        private void WhenIsMiddle(int length) => result = FpFilters.PositionFilters.PositionFilters.IsMiddle(arg, length);
+        private void WhenIsFirst() => result = FpFilters.PositionFilters.IsFirst(arg);
+        private void WhenIsLast(int length) => result = FpFilters.PositionFilters.IsLast(arg, length);
+        private void WhenIsMiddle(int length) => result = FpFilters.PositionFilters.IsMiddle(arg, length);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 

--- a/src/csharp/FpFilters.Tests/PositionFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/PositionFiltersTests.cs
@@ -1,34 +1,34 @@
-namespace FpFilters.PositionFilters.Tests
+namespace FpFilters.Tests
 {
     public class PositionFiltersTests
     {
         [Fact]
         public void IsOddIndex_WorksCorrectly()
         {
-            Assert.True(PositionFilters.IsOddIndex(1));
-            Assert.False(PositionFilters.IsOddIndex(0));
-            Assert.True(PositionFilters.IsOddIndex(3));
+            Assert.True(FpFilters.PositionFilters.IsOddIndex(1));
+            Assert.False(FpFilters.PositionFilters.IsOddIndex(0));
+            Assert.True(FpFilters.PositionFilters.IsOddIndex(3));
         }
 
         [Fact]
         public void IsEvenIndex_WorksCorrectly()
         {
-            Assert.True(PositionFilters.IsEvenIndex(0));
-            Assert.False(PositionFilters.IsEvenIndex(1));
-            Assert.True(PositionFilters.IsEvenIndex(2));
+            Assert.True(FpFilters.PositionFilters.IsEvenIndex(0));
+            Assert.False(FpFilters.PositionFilters.IsEvenIndex(1));
+            Assert.True(FpFilters.PositionFilters.IsEvenIndex(2));
         }
 
         [Fact]
         public void IsEveryNthIndex_WorksCorrectly()
         {
-            Assert.True(PositionFilters.IsEveryNthIndex(0, 3));
-            Assert.False(PositionFilters.IsEveryNthIndex(1, 3));
-            Assert.True(PositionFilters.IsEveryNthIndex(3, 3));
-            Assert.True(PositionFilters.IsEveryNthIndex(4, 2));
-            Assert.True(PositionFilters.IsEveryNthIndex(2, 2));
-            Assert.True(PositionFilters.IsEveryNthIndex(5, 5));
-            Assert.True(PositionFilters.IsEveryNthIndex(2, 3, 2));
-            Assert.False(PositionFilters.IsEveryNthIndex(1, 3, 2));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(0, 3));
+            Assert.False(FpFilters.PositionFilters.IsEveryNthIndex(1, 3));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(3, 3));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(4, 2));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(2, 2));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(5, 5));
+            Assert.True(FpFilters.PositionFilters.IsEveryNthIndex(2, 3, 2));
+            Assert.False(FpFilters.PositionFilters.IsEveryNthIndex(1, 3, 2));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/StringFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/StringFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.StringFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("StringFilters: BDD scenarios for string filter functions.")]
     public class StringFiltersFeature : FeatureFixture
@@ -9,20 +9,20 @@ namespace FpFilters.StringFilters.BddTests
 
         private void GivenString(string value) => arg = value;
         private void GivenComparison(string value) => comparison = value;
-        private void WhenStartsWith() => result = FpFilters.StringFilters.StringFilters.StartsWith(arg, comparison!);
-        private void WhenEndsWith() => result = FpFilters.StringFilters.StringFilters.EndsWith(arg, comparison!);
-        private void WhenIncludes() => result = FpFilters.StringFilters.StringFilters.Includes(arg, comparison!);
-        private void WhenIsEmptyString() => result = FpFilters.StringFilters.StringFilters.IsEmptyString(arg);
-        private void WhenIsEmptyStringTrim() => result = FpFilters.StringFilters.StringFilters.IsEmptyStringTrim(arg);
-        private void WhenIsLowerCase() => result = FpFilters.StringFilters.StringFilters.IsLowerCase(arg);
-        private void WhenIsUpperCase() => result = FpFilters.StringFilters.StringFilters.IsUpperCase(arg);
-        private void WhenIsMixedCase() => result = FpFilters.StringFilters.StringFilters.IsMixedCase(arg);
-        private void WhenIsUniformCase() => result = FpFilters.StringFilters.StringFilters.IsUniformCase(arg);
-        private void WhenIsTrimmable() => result = FpFilters.StringFilters.StringFilters.IsTrimmable(arg);
-        private void WhenIsPalindrome() => result = FpFilters.StringFilters.StringFilters.IsPalindrome(arg);
-        private void WhenMatches(string pattern) => result = FpFilters.StringFilters.StringFilters.Matches(arg, pattern);
-        private void WhenDoesNotMatch(string pattern) => result = FpFilters.StringFilters.StringFilters.DoesNotMatch(arg, pattern);
-        private void WhenIsEmail() => result = FpFilters.StringFilters.StringFilters.IsEmail(arg);
+        private void WhenStartsWith() => result = FpFilters.StringFilters.StartsWith(arg, comparison!);
+        private void WhenEndsWith() => result = FpFilters.StringFilters.EndsWith(arg, comparison!);
+        private void WhenIncludes() => result = FpFilters.StringFilters.Includes(arg, comparison!);
+        private void WhenIsEmptyString() => result = FpFilters.StringFilters.IsEmptyString(arg);
+        private void WhenIsEmptyStringTrim() => result = FpFilters.StringFilters.IsEmptyStringTrim(arg);
+        private void WhenIsLowerCase() => result = FpFilters.StringFilters.IsLowerCase(arg);
+        private void WhenIsUpperCase() => result = FpFilters.StringFilters.IsUpperCase(arg);
+        private void WhenIsMixedCase() => result = FpFilters.StringFilters.IsMixedCase(arg);
+        private void WhenIsUniformCase() => result = FpFilters.StringFilters.IsUniformCase(arg);
+        private void WhenIsTrimmable() => result = FpFilters.StringFilters.IsTrimmable(arg);
+        private void WhenIsPalindrome() => result = FpFilters.StringFilters.IsPalindrome(arg);
+        private void WhenMatches(string pattern) => result = FpFilters.StringFilters.Matches(arg, pattern);
+        private void WhenDoesNotMatch(string pattern) => result = FpFilters.StringFilters.DoesNotMatch(arg, pattern);
+        private void WhenIsEmail() => result = FpFilters.StringFilters.IsEmail(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -217,11 +217,11 @@ namespace FpFilters.StringFilters.BddTests
             );
         }
 
-        private void WhenStartsWithLinq(string substring) => result = FpFilters.StringFilters.StringFilters.StartsWith(substring)(arg);
-        private void WhenEndsWithLinq(string substring) => result = FpFilters.StringFilters.StringFilters.EndsWith(substring)(arg);
-        private void WhenIncludesLinq(string substring) => result = FpFilters.StringFilters.StringFilters.Includes(substring)(arg);
-        private void WhenMatchesLinq(string pattern, string value) => result = FpFilters.StringFilters.StringFilters.Matches(pattern)(value);
-        private void WhenDoesNotMatchLinq(string pattern, string value) => result = FpFilters.StringFilters.StringFilters.DoesNotMatch(pattern)(value);
+        private void WhenStartsWithLinq(string substring) => result = FpFilters.StringFilters.StartsWith(substring)(arg);
+        private void WhenEndsWithLinq(string substring) => result = FpFilters.StringFilters.EndsWith(substring)(arg);
+        private void WhenIncludesLinq(string substring) => result = FpFilters.StringFilters.Includes(substring)(arg);
+        private void WhenMatchesLinq(string pattern, string value) => result = FpFilters.StringFilters.Matches(pattern)(value);
+        private void WhenDoesNotMatchLinq(string pattern, string value) => result = FpFilters.StringFilters.DoesNotMatch(pattern)(value);
 
         [Scenario]
         public void Should_support_linq_overloads_for_two_arg_functions()
@@ -241,12 +241,12 @@ namespace FpFilters.StringFilters.BddTests
             );
         }
 
-        private void WhenStartsWithComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.StartsWith(arg, substring, comparisonType);
-        private void WhenStartsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.StartsWith(substring, comparisonType)(arg);
-        private void WhenEndsWithComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.EndsWith(arg, substring, comparisonType);
-        private void WhenEndsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.EndsWith(substring, comparisonType)(arg);
-        private void WhenIncludesComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.Includes(arg, substring, comparisonType);
-        private void WhenIncludesLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StringFilters.Includes(substring, comparisonType)(arg);
+        private void WhenStartsWithComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StartsWith(arg, substring, comparisonType);
+        private void WhenStartsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.StartsWith(substring, comparisonType)(arg);
+        private void WhenEndsWithComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.EndsWith(arg, substring, comparisonType);
+        private void WhenEndsWithLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.EndsWith(substring, comparisonType)(arg);
+        private void WhenIncludesComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.Includes(arg, substring, comparisonType);
+        private void WhenIncludesLinqComparison(string substring, StringComparison comparisonType) => result = FpFilters.StringFilters.Includes(substring, comparisonType)(arg);
 
         [Scenario]
         public void Should_check_startswith_and_endswith_with_stringcomparison()

--- a/src/csharp/FpFilters.Tests/StringFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/StringFiltersTests.cs
@@ -1,141 +1,141 @@
-namespace FpFilters.StringFilters.Tests
+namespace FpFilters.Tests
 {
     public class StringFiltersTests
     {
         [Fact]
         public void StartsWith_ReturnsTrueForPrefix()
         {
-            Assert.True(StringFilters.StartsWith("hello world", "hello"));
-            Assert.False(StringFilters.StartsWith("hello world", "world"));
+            Assert.True(FpFilters.StringFilters.StartsWith("hello world", "hello"));
+            Assert.False(FpFilters.StringFilters.StartsWith("hello world", "world"));
         }
 
         [Fact]
         public void EndsWith_ReturnsTrueForSuffix()
         {
-            Assert.True(StringFilters.EndsWith("hello world", "world"));
-            Assert.False(StringFilters.EndsWith("hello world", "hello"));
+            Assert.True(FpFilters.StringFilters.EndsWith("hello world", "world"));
+            Assert.False(FpFilters.StringFilters.EndsWith("hello world", "hello"));
         }
 
         [Fact]
         public void Includes_ReturnsTrueForSubstring()
         {
-            Assert.True(StringFilters.Includes("hello world", "lo wo"));
-            Assert.False(StringFilters.Includes("hello world", "test"));
+            Assert.True(FpFilters.StringFilters.Includes("hello world", "lo wo"));
+            Assert.False(FpFilters.StringFilters.Includes("hello world", "test"));
         }
 
         [Fact]
         public void IsEmptyString_ReturnsTrueForEmpty()
         {
-            Assert.True(StringFilters.IsEmptyString(""));
-            Assert.False(StringFilters.IsEmptyString("not empty"));
+            Assert.True(FpFilters.StringFilters.IsEmptyString(""));
+            Assert.False(FpFilters.StringFilters.IsEmptyString("not empty"));
         }
 
         [Fact]
         public void IsEmptyStringTrim_ReturnsTrueForWhitespace()
         {
-            Assert.True(StringFilters.IsEmptyStringTrim("   "));
-            Assert.False(StringFilters.IsEmptyStringTrim("not empty"));
+            Assert.True(FpFilters.StringFilters.IsEmptyStringTrim("   "));
+            Assert.False(FpFilters.StringFilters.IsEmptyStringTrim("not empty"));
         }
 
         [Fact]
         public void IsLowerCase_ReturnsTrueForLower()
         {
-            Assert.True(StringFilters.IsLowerCase("abc"));
-            Assert.False(StringFilters.IsLowerCase("Abc"));
+            Assert.True(FpFilters.StringFilters.IsLowerCase("abc"));
+            Assert.False(FpFilters.StringFilters.IsLowerCase("Abc"));
         }
 
         [Fact]
         public void IsUpperCase_ReturnsTrueForUpper()
         {
-            Assert.True(StringFilters.IsUpperCase("ABC"));
-            Assert.False(StringFilters.IsUpperCase("Abc"));
+            Assert.True(FpFilters.StringFilters.IsUpperCase("ABC"));
+            Assert.False(FpFilters.StringFilters.IsUpperCase("Abc"));
         }
 
         [Fact]
         public void IsMixedCase_ReturnsTrueForMixed()
         {
-            Assert.True(StringFilters.IsMixedCase("Abc"));
-            Assert.False(StringFilters.IsMixedCase("abc"));
-            Assert.False(StringFilters.IsMixedCase("ABC"));
+            Assert.True(FpFilters.StringFilters.IsMixedCase("Abc"));
+            Assert.False(FpFilters.StringFilters.IsMixedCase("abc"));
+            Assert.False(FpFilters.StringFilters.IsMixedCase("ABC"));
         }
 
         [Fact]
         public void IsUniformCase_ReturnsTrueForUniform()
         {
-            Assert.True(StringFilters.IsUniformCase("abc"));
-            Assert.True(StringFilters.IsUniformCase("ABC"));
-            Assert.False(StringFilters.IsUniformCase("Abc"));
+            Assert.True(FpFilters.StringFilters.IsUniformCase("abc"));
+            Assert.True(FpFilters.StringFilters.IsUniformCase("ABC"));
+            Assert.False(FpFilters.StringFilters.IsUniformCase("Abc"));
         }
 
         [Fact]
         public void IsTrimmable_ReturnsTrueForTrimmable()
         {
-            Assert.True(StringFilters.IsTrimmable(" abc "));
-            Assert.False(StringFilters.IsTrimmable("abc"));
+            Assert.True(FpFilters.StringFilters.IsTrimmable(" abc "));
+            Assert.False(FpFilters.StringFilters.IsTrimmable("abc"));
         }
 
         [Fact]
         public void IsPalindrome_ReturnsTrueForPalindrome()
         {
-            Assert.True(StringFilters.IsPalindrome("madam"));
-            Assert.False(StringFilters.IsPalindrome("hello"));
+            Assert.True(FpFilters.StringFilters.IsPalindrome("madam"));
+            Assert.False(FpFilters.StringFilters.IsPalindrome("hello"));
         }
 
         [Fact]
         public void Matches_ReturnsTrueForPattern()
         {
-            Assert.True(StringFilters.Matches("abc123", "[a-z]+[0-9]+"));
-            Assert.False(StringFilters.Matches("abc", "[0-9]+"));
+            Assert.True(FpFilters.StringFilters.Matches("abc123", "[a-z]+[0-9]+"));
+            Assert.False(FpFilters.StringFilters.Matches("abc", "[0-9]+"));
         }
 
         [Fact]
         public void DoesNotMatch_ReturnsTrueForNonMatch()
         {
-            Assert.True(StringFilters.DoesNotMatch("abc", "[0-9]+"));
-            Assert.False(StringFilters.DoesNotMatch("abc123", "[a-z]+[0-9]+"));
+            Assert.True(FpFilters.StringFilters.DoesNotMatch("abc", "[0-9]+"));
+            Assert.False(FpFilters.StringFilters.DoesNotMatch("abc123", "[a-z]+[0-9]+"));
         }
 
         [Fact]
         public void IsEmail_ReturnsTrueForValidEmail()
         {
-            Assert.True(StringFilters.IsEmail("test@example.com"));
-            Assert.False(StringFilters.IsEmail("not-an-email"));
+            Assert.True(FpFilters.StringFilters.IsEmail("test@example.com"));
+            Assert.False(FpFilters.StringFilters.IsEmail("not-an-email"));
         }
 
         [Fact]
         public void AllMethods_HandleNullInput()
         {
-            Assert.False(StringFilters.StartsWith(null, "x"));
-            Assert.False(StringFilters.EndsWith(null, "x"));
-            Assert.False(StringFilters.Includes(null, "x"));
-            Assert.False(StringFilters.IsEmptyString(null));
-            Assert.False(StringFilters.IsEmptyStringTrim(null));
-            Assert.False(StringFilters.IsLowerCase(null));
-            Assert.False(StringFilters.IsUpperCase(null));
-            Assert.False(StringFilters.IsMixedCase(null));
-            Assert.False(StringFilters.IsUniformCase(null));
-            Assert.False(StringFilters.IsTrimmable(null));
-            Assert.False(StringFilters.IsTrimmableStart(null));
-            Assert.False(StringFilters.IsTrimmableEnd(null));
-            Assert.False(StringFilters.IsPalindrome(null));
-            Assert.False(StringFilters.Matches(null, "x"));
-            Assert.True(StringFilters.DoesNotMatch(null, "x"));
-            Assert.False(StringFilters.IsEmail(null));
+            Assert.False(FpFilters.StringFilters.StartsWith(null, "x"));
+            Assert.False(FpFilters.StringFilters.EndsWith(null, "x"));
+            Assert.False(FpFilters.StringFilters.Includes(null, "x"));
+            Assert.False(FpFilters.StringFilters.IsEmptyString(null));
+            Assert.False(FpFilters.StringFilters.IsEmptyStringTrim(null));
+            Assert.False(FpFilters.StringFilters.IsLowerCase(null));
+            Assert.False(FpFilters.StringFilters.IsUpperCase(null));
+            Assert.False(FpFilters.StringFilters.IsMixedCase(null));
+            Assert.False(FpFilters.StringFilters.IsUniformCase(null));
+            Assert.False(FpFilters.StringFilters.IsTrimmable(null));
+            Assert.False(FpFilters.StringFilters.IsTrimmableStart(null));
+            Assert.False(FpFilters.StringFilters.IsTrimmableEnd(null));
+            Assert.False(FpFilters.StringFilters.IsPalindrome(null));
+            Assert.False(FpFilters.StringFilters.Matches(null, "x"));
+            Assert.True(FpFilters.StringFilters.DoesNotMatch(null, "x"));
+            Assert.False(FpFilters.StringFilters.IsEmail(null));
         }
 
         [Fact]
         public void IsTrimmableStartAndEnd_Tests()
         {
-            Assert.True(StringFilters.IsTrimmableStart(" abc"));
-            Assert.False(StringFilters.IsTrimmableStart("abc "));
-            Assert.False(StringFilters.IsTrimmableStart("abc"));
-            Assert.True(StringFilters.IsTrimmableEnd("abc "));
-            Assert.False(StringFilters.IsTrimmableEnd(" abc"));
-            Assert.False(StringFilters.IsTrimmableEnd("abc"));
-            Assert.False(StringFilters.IsTrimmableStart(""));
-            Assert.False(StringFilters.IsTrimmableEnd(""));
-            Assert.True(StringFilters.IsTrimmableStart("   "));
-            Assert.True(StringFilters.IsTrimmableEnd("   "));
+            Assert.True(FpFilters.StringFilters.IsTrimmableStart(" abc"));
+            Assert.False(FpFilters.StringFilters.IsTrimmableStart("abc "));
+            Assert.False(FpFilters.StringFilters.IsTrimmableStart("abc"));
+            Assert.True(FpFilters.StringFilters.IsTrimmableEnd("abc "));
+            Assert.False(FpFilters.StringFilters.IsTrimmableEnd(" abc"));
+            Assert.False(FpFilters.StringFilters.IsTrimmableEnd("abc"));
+            Assert.False(FpFilters.StringFilters.IsTrimmableStart(""));
+            Assert.False(FpFilters.StringFilters.IsTrimmableEnd(""));
+            Assert.True(FpFilters.StringFilters.IsTrimmableStart("   "));
+            Assert.True(FpFilters.StringFilters.IsTrimmableEnd("   "));
         }
     }
 }

--- a/src/csharp/FpFilters.Tests/TypeFiltersBddTests.cs
+++ b/src/csharp/FpFilters.Tests/TypeFiltersBddTests.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.TypeFilters.BddTests
+namespace FpFilters.BddTests
 {
     [FeatureDescription("TypeFilters: BDD scenarios for type filter functions.")]
     public class TypeFiltersFeature : FeatureFixture
@@ -9,14 +9,14 @@ namespace FpFilters.TypeFilters.BddTests
 
         private void GivenArgument(object? value) => arg = value;
         private void GivenComparison(object? value) => comparison = value;
-        private void WhenIsUndefined() => result = FpFilters.TypeFilters.TypeFilters.IsUndefined(arg);
-        private void WhenIsString() => result = FpFilters.TypeFilters.TypeFilters.IsString(arg);
-        private void WhenIsNumber() => result = FpFilters.TypeFilters.TypeFilters.IsNumber(arg);
-        private void WhenIsObject() => result = FpFilters.TypeFilters.TypeFilters.IsObject(arg);
-        private void WhenIsNull() => result = FpFilters.TypeFilters.TypeFilters.IsNull(arg);
-        private void WhenIsBoolean() => result = FpFilters.TypeFilters.TypeFilters.IsBoolean(arg);
-        private void WhenIsDate() => result = FpFilters.TypeFilters.TypeFilters.IsDate(arg);
-        private void WhenIsArray() => result = FpFilters.TypeFilters.TypeFilters.IsArray(arg);
+        private void WhenIsUndefined() => result = FpFilters.TypeFilters.IsUndefined(arg);
+        private void WhenIsString() => result = FpFilters.TypeFilters.IsString(arg);
+        private void WhenIsNumber() => result = FpFilters.TypeFilters.IsNumber(arg);
+        private void WhenIsObject() => result = FpFilters.TypeFilters.IsObject(arg);
+        private void WhenIsNull() => result = FpFilters.TypeFilters.IsNull(arg);
+        private void WhenIsBoolean() => result = FpFilters.TypeFilters.IsBoolean(arg);
+        private void WhenIsDate() => result = FpFilters.TypeFilters.IsDate(arg);
+        private void WhenIsArray() => result = FpFilters.TypeFilters.IsArray(arg);
         private void ThenResultShouldBeTrue() => Xunit.Assert.True(result);
         private void ThenResultShouldBeFalse() => Xunit.Assert.False(result);
 
@@ -133,10 +133,10 @@ namespace FpFilters.TypeFilters.BddTests
         [Scenario]
         public void Should_check_IsSameTypeAs_linq()
         {
-            var isSameTypeAsInt = FpFilters.TypeFilters.TypeFilters.IsSameTypeAs(42);
+            var isSameTypeAsInt = FpFilters.TypeFilters.IsSameTypeAs(42);
             Xunit.Assert.True(isSameTypeAsInt(123));
             Xunit.Assert.False(isSameTypeAsInt("string"));
-            var isSameTypeAsStr = FpFilters.TypeFilters.TypeFilters.IsSameTypeAs("abc");
+            var isSameTypeAsStr = FpFilters.TypeFilters.IsSameTypeAs("abc");
             Xunit.Assert.True(isSameTypeAsStr("def"));
             Xunit.Assert.False(isSameTypeAsStr(42));
         }
@@ -144,10 +144,10 @@ namespace FpFilters.TypeFilters.BddTests
         [Scenario]
         public void Should_check_IsNotSameTypeAs_linq()
         {
-            var isNotSameTypeAsInt = FpFilters.TypeFilters.TypeFilters.IsNotSameTypeAs(42);
+            var isNotSameTypeAsInt = FpFilters.TypeFilters.IsNotSameTypeAs(42);
             Xunit.Assert.False(isNotSameTypeAsInt(123));
             Xunit.Assert.True(isNotSameTypeAsInt("string"));
-            var isNotSameTypeAsStr = FpFilters.TypeFilters.TypeFilters.IsNotSameTypeAs("abc");
+            var isNotSameTypeAsStr = FpFilters.TypeFilters.IsNotSameTypeAs("abc");
             Xunit.Assert.False(isNotSameTypeAsStr("def"));
             Xunit.Assert.True(isNotSameTypeAsStr(42));
         }
@@ -155,10 +155,10 @@ namespace FpFilters.TypeFilters.BddTests
         [Scenario]
         public void Should_check_IsOfType_linq()
         {
-            var isOfTypeInt = FpFilters.TypeFilters.TypeFilters.IsOfType(typeof(int));
+            var isOfTypeInt = FpFilters.TypeFilters.IsOfType(typeof(int));
             Xunit.Assert.True(isOfTypeInt(42));
             Xunit.Assert.False(isOfTypeInt("string"));
-            var isOfTypeStr = FpFilters.TypeFilters.TypeFilters.IsOfType(typeof(string));
+            var isOfTypeStr = FpFilters.TypeFilters.IsOfType(typeof(string));
             Xunit.Assert.True(isOfTypeStr("abc"));
             Xunit.Assert.False(isOfTypeStr(42));
         }
@@ -166,10 +166,10 @@ namespace FpFilters.TypeFilters.BddTests
         [Scenario]
         public void Should_check_IsNotOfType_linq()
         {
-            var isNotOfTypeInt = FpFilters.TypeFilters.TypeFilters.IsNotOfType(typeof(int));
+            var isNotOfTypeInt = FpFilters.TypeFilters.IsNotOfType(typeof(int));
             Xunit.Assert.False(isNotOfTypeInt(42));
             Xunit.Assert.True(isNotOfTypeInt("string"));
-            var isNotOfTypeStr = FpFilters.TypeFilters.TypeFilters.IsNotOfType(typeof(string));
+            var isNotOfTypeStr = FpFilters.TypeFilters.IsNotOfType(typeof(string));
             Xunit.Assert.False(isNotOfTypeStr("abc"));
             Xunit.Assert.True(isNotOfTypeStr(42));
         }

--- a/src/csharp/FpFilters.Tests/TypeFiltersTests.cs
+++ b/src/csharp/FpFilters.Tests/TypeFiltersTests.cs
@@ -1,114 +1,114 @@
-namespace FpFilters.TypeFilters.Tests
+namespace FpFilters.Tests
 {
     public class TypeFiltersTests
     {
         [Fact]
         public void IsUndefined_ReturnsTrueForNull()
         {
-            Assert.True(TypeFilters.IsUndefined(null));
+            Assert.True(FpFilters.TypeFilters.IsUndefined(null));
         }
 
         [Fact]
         public void IsString_ReturnsTrueForString()
         {
-            Assert.True(TypeFilters.IsString("hello"));
-            Assert.False(TypeFilters.IsString(123));
+            Assert.True(FpFilters.TypeFilters.IsString("hello"));
+            Assert.False(FpFilters.TypeFilters.IsString(123));
         }
 
         [Fact]
         public void IsNumber_ReturnsTrueForNumbers()
         {
-            Assert.True(TypeFilters.IsNumber(123));
-            Assert.True(TypeFilters.IsNumber(123.45));
-            Assert.False(TypeFilters.IsNumber("123"));
+            Assert.True(FpFilters.TypeFilters.IsNumber(123));
+            Assert.True(FpFilters.TypeFilters.IsNumber(123.45));
+            Assert.False(FpFilters.TypeFilters.IsNumber("123"));
         }
 
         [Fact]
         public void IsObject_ReturnsTrueForObject()
         {
-            Assert.True(TypeFilters.IsObject(new object()));
-            Assert.False(TypeFilters.IsObject(123));
-            Assert.False(TypeFilters.IsObject("string"));
+            Assert.True(FpFilters.TypeFilters.IsObject(new object()));
+            Assert.False(FpFilters.TypeFilters.IsObject(123));
+            Assert.False(FpFilters.TypeFilters.IsObject("string"));
         }
 
         [Fact]
         public void IsNull_ReturnsTrueForNull()
         {
-            Assert.True(TypeFilters.IsNull(null));
-            Assert.False(TypeFilters.IsNull("not null"));
+            Assert.True(FpFilters.TypeFilters.IsNull(null));
+            Assert.False(FpFilters.TypeFilters.IsNull("not null"));
         }
 
         [Fact]
         public void IsBoolean_ReturnsTrueForBool()
         {
-            Assert.True(TypeFilters.IsBoolean(true));
-            Assert.True(TypeFilters.IsBoolean(false));
-            Assert.False(TypeFilters.IsBoolean("true"));
+            Assert.True(FpFilters.TypeFilters.IsBoolean(true));
+            Assert.True(FpFilters.TypeFilters.IsBoolean(false));
+            Assert.False(FpFilters.TypeFilters.IsBoolean("true"));
         }
 
         [Fact]
         public void IsDate_ReturnsTrueForDateTime()
         {
-            Assert.True(TypeFilters.IsDate(System.DateTime.Now));
-            Assert.False(TypeFilters.IsDate("2025-09-07"));
+            Assert.True(FpFilters.TypeFilters.IsDate(System.DateTime.Now));
+            Assert.False(FpFilters.TypeFilters.IsDate("2025-09-07"));
         }
 
         [Fact]
         public void IsArray_ReturnsTrueForArray()
         {
-            Assert.True(TypeFilters.IsArray(new int[] { 1, 2, 3 }));
-            Assert.False(TypeFilters.IsArray("array"));
+            Assert.True(FpFilters.TypeFilters.IsArray(new int[] { 1, 2, 3 }));
+            Assert.False(FpFilters.TypeFilters.IsArray("array"));
         }
 
         [Fact]
         public void IsNotMethods_Coverage()
         {
-            Assert.False(TypeFilters.IsNotUndefined(null));
-            Assert.True(TypeFilters.IsNotUndefined("abc"));
-            Assert.False(TypeFilters.IsNotString("abc"));
-            Assert.True(TypeFilters.IsNotString(123));
-            Assert.False(TypeFilters.IsNotNumber(123));
-            Assert.True(TypeFilters.IsNotNumber("abc"));
-            Assert.False(TypeFilters.IsNotObject(new object()));
-            Assert.True(TypeFilters.IsNotObject(123));
-            Assert.True(TypeFilters.IsNotNull("abc"));
-            Assert.False(TypeFilters.IsNotNull(null));
-            Assert.False(TypeFilters.IsNotBoolean(true));
-            Assert.True(TypeFilters.IsNotBoolean("abc"));
-            Assert.False(TypeFilters.IsNotDate(System.DateTime.Now));
-            Assert.True(TypeFilters.IsNotDate("abc"));
-            Assert.False(TypeFilters.IsNotArray(new int[] { 1 }));
-            Assert.True(TypeFilters.IsNotArray("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotUndefined(null));
+            Assert.True(FpFilters.TypeFilters.IsNotUndefined("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotString("abc"));
+            Assert.True(FpFilters.TypeFilters.IsNotString(123));
+            Assert.False(FpFilters.TypeFilters.IsNotNumber(123));
+            Assert.True(FpFilters.TypeFilters.IsNotNumber("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotObject(new object()));
+            Assert.True(FpFilters.TypeFilters.IsNotObject(123));
+            Assert.True(FpFilters.TypeFilters.IsNotNull("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotNull(null));
+            Assert.False(FpFilters.TypeFilters.IsNotBoolean(true));
+            Assert.True(FpFilters.TypeFilters.IsNotBoolean("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotDate(System.DateTime.Now));
+            Assert.True(FpFilters.TypeFilters.IsNotDate("abc"));
+            Assert.False(FpFilters.TypeFilters.IsNotArray(new int[] { 1 }));
+            Assert.True(FpFilters.TypeFilters.IsNotArray("abc"));
         }
 
         [Fact]
         public void IsSameTypeAs_And_NotSameTypeAs_Coverage()
         {
-            Assert.True(TypeFilters.IsSameTypeAs("abc", "def"));
-            Assert.False(TypeFilters.IsSameTypeAs("abc", 123));
-            Assert.True(TypeFilters.IsNotSameTypeAs("abc", 123));
-            Assert.False(TypeFilters.IsNotSameTypeAs("abc", "def"));
-            Assert.False(TypeFilters.IsSameTypeAs(null, "def"));
-            Assert.True(TypeFilters.IsNotSameTypeAs(null, "def"));
+            Assert.True(FpFilters.TypeFilters.IsSameTypeAs("abc", "def"));
+            Assert.False(FpFilters.TypeFilters.IsSameTypeAs("abc", 123));
+            Assert.True(FpFilters.TypeFilters.IsNotSameTypeAs("abc", 123));
+            Assert.False(FpFilters.TypeFilters.IsNotSameTypeAs("abc", "def"));
+            Assert.False(FpFilters.TypeFilters.IsSameTypeAs(null, "def"));
+            Assert.True(FpFilters.TypeFilters.IsNotSameTypeAs(null, "def"));
         }
 
         [Fact]
         public void IsOfType_And_IsNotOfType_Coverage()
         {
-            Assert.True(TypeFilters.IsOfType("abc", typeof(string)));
-            Assert.False(TypeFilters.IsOfType(123, typeof(string)));
-            Assert.False(TypeFilters.IsOfType(null, typeof(string)));
-            Assert.False(TypeFilters.IsNotOfType("abc", typeof(string)));
-            Assert.True(TypeFilters.IsNotOfType(123, typeof(string)));
-            Assert.True(TypeFilters.IsNotOfType(null, typeof(string)));
+            Assert.True(FpFilters.TypeFilters.IsOfType("abc", typeof(string)));
+            Assert.False(FpFilters.TypeFilters.IsOfType(123, typeof(string)));
+            Assert.False(FpFilters.TypeFilters.IsOfType(null, typeof(string)));
+            Assert.False(FpFilters.TypeFilters.IsNotOfType("abc", typeof(string)));
+            Assert.True(FpFilters.TypeFilters.IsNotOfType(123, typeof(string)));
+            Assert.True(FpFilters.TypeFilters.IsNotOfType(null, typeof(string)));
         }
 
         [Fact]
         public void IsInstanceOf_Coverage()
         {
-            Assert.True(TypeFilters.IsInstanceOf<string>("abc"));
-            Assert.False(TypeFilters.IsInstanceOf<int>("abc"));
-            Assert.False(TypeFilters.IsInstanceOf<string>(null));
+            Assert.True(FpFilters.TypeFilters.IsInstanceOf<string>("abc"));
+            Assert.False(FpFilters.TypeFilters.IsInstanceOf<int>("abc"));
+            Assert.False(FpFilters.TypeFilters.IsInstanceOf<string>(null));
         }
 
         // Additional tests for Not* and SameTypeAs, etc. can be added similarly

--- a/src/csharp/FpFilters/ArrayFilters/ArrayFilters.cs
+++ b/src/csharp/FpFilters/ArrayFilters/ArrayFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ArrayFilters
+namespace FpFilters
 {
     public static class ArrayFilters
     {

--- a/src/csharp/FpFilters/BooleanFilters/BooleanFilters.cs
+++ b/src/csharp/FpFilters/BooleanFilters/BooleanFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.BooleanFilters
+namespace FpFilters
 {
     public static class BooleanFilters
     {

--- a/src/csharp/FpFilters/Class1.cs
+++ b/src/csharp/FpFilters/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace FpFilters;
-
-public class Class1
-{
-
-}

--- a/src/csharp/FpFilters/DateFilters/DateFilters.cs
+++ b/src/csharp/FpFilters/DateFilters/DateFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.DateFilters
+namespace FpFilters
 {
     public static class DateFilters
     {

--- a/src/csharp/FpFilters/LengthFilters/LengthFilters.cs
+++ b/src/csharp/FpFilters/LengthFilters/LengthFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.LengthFilters
+namespace FpFilters
 {
     public static class LengthFilters
     {

--- a/src/csharp/FpFilters/MiscFilters/MiscFilters.cs
+++ b/src/csharp/FpFilters/MiscFilters/MiscFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.MiscFilters
+namespace FpFilters
 {
     public static class MiscFilters
     {

--- a/src/csharp/FpFilters/NumberFilters/NumberFilters.cs
+++ b/src/csharp/FpFilters/NumberFilters/NumberFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.NumberFilters
+namespace FpFilters
 {
     /// <summary>
     /// Provides a set of static methods for filtering and comparing numbers.

--- a/src/csharp/FpFilters/ObjectFilters/ObjectFilters.cs
+++ b/src/csharp/FpFilters/ObjectFilters/ObjectFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.ObjectFilters
+namespace FpFilters
 {
     public static class ObjectFilters
     {

--- a/src/csharp/FpFilters/PositionFilters/PositionFilters.cs
+++ b/src/csharp/FpFilters/PositionFilters/PositionFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.PositionFilters
+namespace FpFilters
 {
     public static class PositionFilters
     {

--- a/src/csharp/FpFilters/StringFilters/StringFilters.cs
+++ b/src/csharp/FpFilters/StringFilters/StringFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.StringFilters
+namespace FpFilters
 {
     public static class StringFilters
     {

--- a/src/csharp/FpFilters/TypeFilters/TypeFilters.cs
+++ b/src/csharp/FpFilters/TypeFilters/TypeFilters.cs
@@ -1,4 +1,4 @@
-namespace FpFilters.TypeFilters
+namespace FpFilters
 {
     public static class TypeFilters
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Flattened C# namespaces: public types moved from nested containers (e.g., FpFilters.XxxFilters.XxxFilters) to FpFilters.XxxFilters. Update using/qualified names across Array, Boolean, Date, Length, Misc, Number, Object, Position, String, and Type filters.
  - Removed an empty placeholder class from the public surface.

- Refactor
  - Simplified API surface; no behavioral changes to filter methods.

- Tests
  - Updated test namespaces and references to align with the new public API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->