### PR TITLE
Add NuGet packaging and publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-          cache: true
+          # cache: true
       - name: Install ReportGenerator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Run tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'\
+          dotnet-version: '9.0.x'
           cache: true
       - name: Install ReportGenerator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '9.0.x'\
+          cache: true
       - name: Install ReportGenerator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Run tests with coverage

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -24,3 +24,5 @@ jobs:
         run: dotnet pack src/csharp/FpFilters/FpFilters.csproj -p:Version=${GITHUB_REF_NAME#v} --configuration Release --no-build --output ./nupkg
       - name: Publish to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      - name: Publish to NuGet
+        run: dotnet nuget push ./nupkg/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -15,11 +15,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
+          cache: true
       - name: Restore dependencies
         run: dotnet restore src/csharp/FpFilters/FpFilters.csproj
       - name: Build
         run: dotnet build src/csharp/FpFilters/FpFilters.csproj --configuration Release --no-restore
       - name: Pack
-        run: dotnet pack src/csharp/FpFilters/FpFilters.csproj --configuration Release --no-build --output ./nupkg
+        run: dotnet pack src/csharp/FpFilters/FpFilters.csproj -p:Version=${GITHUB_REF_NAME#v} --configuration Release --no-build --output ./nupkg
       - name: Publish to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-          cache: true
+          # cache: true
       - name: Restore dependencies
         run: dotnet restore src/csharp/FpFilters/FpFilters.csproj
       - name: Build

--- a/src/csharp/.github/workflows/nuget-publish.yml
+++ b/src/csharp/.github/workflows/nuget-publish.yml
@@ -1,0 +1,25 @@
+name: NuGet Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore dependencies
+        run: dotnet restore src/csharp/FpFilters/FpFilters.csproj
+      - name: Build
+        run: dotnet build src/csharp/FpFilters/FpFilters.csproj --configuration Release --no-restore
+      - name: Pack
+        run: dotnet pack src/csharp/FpFilters/FpFilters.csproj --configuration Release --no-build --output ./nupkg
+      - name: Publish to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/src/csharp/FpFilters.sln
+++ b/src/csharp/FpFilters.sln
@@ -9,7 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FpFilters.Tests", "FpFilter
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\.github\workflows\.gitlab-ci.yml = ..\..\.github\workflows\.gitlab-ci.yml
+		..\..\.github\workflows\ci.yml = ..\..\.github\workflows\ci.yml
+		..\..\.github\workflows\nuget-publish.yml = ..\..\.github\workflows\nuget-publish.yml
 		run-tests-with-coverage.ps1 = run-tests-with-coverage.ps1
 	EndProjectSection
 EndProject
@@ -50,5 +51,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {77502810-94D4-4B81-AF9E-740C1ED5121D}
 	EndGlobalSection
 EndGlobal

--- a/src/csharp/FpFilters.sln
+++ b/src/csharp/FpFilters.sln
@@ -9,6 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FpFilters.Tests", "FpFilter
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\.github\workflows\.gitlab-ci.yml = ..\..\.github\workflows\.gitlab-ci.yml
 		run-tests-with-coverage.ps1 = run-tests-with-coverage.ps1
 	EndProjectSection
 EndProject

--- a/src/csharp/FpFilters/FpFilters.csproj
+++ b/src/csharp/FpFilters/FpFilters.csproj
@@ -26,5 +26,11 @@
 		<None Include="README.md" Pack="true" PackagePath="" />
 		<None Include="LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 
 </Project>

--- a/src/csharp/FpFilters/FpFilters.csproj
+++ b/src/csharp/FpFilters/FpFilters.csproj
@@ -5,6 +5,22 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- NuGet metadata -->
+    <PackageId>FpFilters</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Andrei Ignat</Authors>
+    <Company>Andrei Ignat</Company>
+    <Description>Filters for LINQ and functional programming in C#.</Description>
+    <PackageTags>filters;linq;functional;fp;dotnet;utility</PackageTags>
+    <RepositoryUrl>https://github.com/ignatandrei/Filters</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/ignatandrei/Filters</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Copyright (c) 2024 Andrei Ignat</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
+    <None Include="LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
 
 </Project>

--- a/src/csharp/FpFilters/FpFilters.csproj
+++ b/src/csharp/FpFilters/FpFilters.csproj
@@ -1,26 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- NuGet metadata -->
-    <PackageId>FpFilters</PackageId>
-    <Version>1.0.0</Version>
-    <Authors>Andrei Ignat</Authors>
-    <Company>Andrei Ignat</Company>
-    <Description>Filters for LINQ and functional programming in C#.</Description>
-    <PackageTags>filters;linq;functional;fp;dotnet;utility</PackageTags>
-    <RepositoryUrl>https://github.com/ignatandrei/Filters</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/ignatandrei/Filters</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright (c) 2024 Andrei Ignat</Copyright>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="" />
-    <None Include="LICENSE" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<!-- NuGet metadata -->
+		<PackageId>FpFilters</PackageId>
+		<Authors>Andrei Ignat</Authors>
+		<Company>Andrei Ignat</Company>
+		<Description>Filters for LINQ and functional programming in C#.</Description>
+		<PackageTags>filters;linq;functional;fp;dotnet;utility</PackageTags>
+		<RepositoryUrl>https://github.com/ignatandrei/Filters</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/ignatandrei/Filters</PackageProjectUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Copyright>Copyright (c) 2024 Andrei Ignat</Copyright>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="LICENSE" Pack="true" PackagePath="" />
+	</ItemGroup>
 
 </Project>

--- a/src/csharp/FpFilters/LICENSE
+++ b/src/csharp/FpFilters/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Andrei Ignat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/csharp/FpFilters/README.md
+++ b/src/csharp/FpFilters/README.md
@@ -1,0 +1,44 @@
+# FpFilters
+
+Filters for LINQ and functional programming in C#.
+
+## Features
+- Type filters (IsString, IsNumber, IsObject, etc.)
+- Miscellaneous filters (Is, IsNot, IsNullOrDefault, etc.)
+- Date, Boolean, Array, Object, String, Number, Length, and Position filters
+
+## Installation
+
+You can install via NuGet:
+
+```
+dotnet add package FpFilters
+```
+
+## Usage
+
+```csharp
+using FpFilters;
+
+var numbers = new[] { 1, 2, 3, 4 };
+var evenNumbers = numbers.Where(FpFilters.NumberFilters.IsEven);
+```
+
+## Building and Publishing
+
+To create and publish the NuGet package:
+
+1. Pack the project:
+   ```
+   dotnet pack -c Release
+   ```
+2. Push to NuGet (replace `<API_KEY>` with your NuGet API key):
+   ```
+   dotnet nuget push bin/Release/FpFilters.*.nupkg --api-key <API_KEY> --source https://api.nuget.org/v3/index.json
+   ```
+
+## License
+MIT
+
+## Project URL
+https://github.com/ignatandrei/Filters


### PR DESCRIPTION
Introduces a GitHub Actions workflow for publishing to NuGet on tag push, adds NuGet metadata to FpFilters.csproj, and includes LICENSE and README files for package distribution. Updates solution to reference CI configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added project README with installation, usage examples, build/publish steps.
  - Included MIT license file.

- Chores
  - Prepared package metadata for NuGet distribution and included README/license in the package.
  - Added source-linking for improved debugging/tracing.
  - Enabled CI caching to speed builds.
  - Added automated workflow to publish NuGet packages on tagged releases.
  - Added solution metadata to support tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->